### PR TITLE
Health check reconciler

### DIFF
--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -38,6 +38,12 @@ type ProviderConfigSpec struct {
 
 	// UseHTTPS ceph cluster configuration.
 	UseHTTPS bool `json:"useHttps,omitempty"`
+
+	DisableHealthCheck bool `json:"disableHealthCheck,omitempty"`
+
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:default:=30
+	HealthCheckIntervalSeconds int32 `json:"healthCheckIntervalSeconds,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.
@@ -52,6 +58,10 @@ type ProviderCredentials struct {
 // A ProviderConfigStatus reflects the observed state of a ProviderConfig.
 type ProviderConfigStatus struct {
 	xpv1.ProviderConfigStatus `json:",inline"`
+
+	// Health of the s3 backend represented by the ProviderConfig determined
+	// by periodic health check.
+	Health string `json:"health,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -55,13 +55,22 @@ type ProviderCredentials struct {
 	xpv1.CommonCredentialSelectors `json:",inline"`
 }
 
+type HealthStatus string
+
+const (
+	HealthStatusHealthy   = "Healthy"
+	HealthStatusUnhealthy = "Unhealthy"
+	HealthStatusDisabled  = "HealthCheckDisabled"
+)
+
 // A ProviderConfigStatus reflects the observed state of a ProviderConfig.
 type ProviderConfigStatus struct {
 	xpv1.ProviderConfigStatus `json:",inline"`
 
 	// Health of the s3 backend represented by the ProviderConfig determined
 	// by periodic health check.
-	Health string `json:"health,omitempty"`
+	//+kubebuilder:validation:Enum=Healthy;Unhealthy;HealthCheckDisabled
+	Health HealthStatus `json:"health,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/e2e/tests/stable/provider-ceph/01-assert.yaml
+++ b/e2e/tests/stable/provider-ceph/01-assert.yaml
@@ -1,0 +1,35 @@
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-a-health-check
+---
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-b-health-check
+---
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-c-health-check
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-a
+status:
+  health: Healthy
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-b
+status:
+  health: Healthy
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-c
+status:
+  health: Healthy

--- a/e2e/tests/stable/provider-ceph/10-delete-provider-configs.yaml
+++ b/e2e/tests/stable/provider-ceph/10-delete-provider-configs.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete provider --all
+  - command: kubectl delete providerconfig --all

--- a/e2e/tests/stable/provider-ceph/10-errors.yaml
+++ b/e2e/tests/stable/provider-ceph/10-errors.yaml
@@ -1,0 +1,29 @@
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-a-health-check
+---
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-b-health-check
+---
+apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+kind: Bucket
+metadata:
+  name: localstack-c-health-check
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-a
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-b
+---
+apiVersion: ceph.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: localstack-c

--- a/internal/controller/ceph.go
+++ b/internal/controller/ceph.go
@@ -22,14 +22,14 @@ import (
 
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/controller/bucket"
-	"github.com/linode/provider-ceph/internal/controller/config"
+	"github.com/linode/provider-ceph/internal/controller/providerconfig"
 )
 
 // Setup creates all Ceph controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options, *backendstore.BackendStore) error{
-		config.Setup,
+		providerconfig.Setup,
 		bucket.Setup,
 	} {
 		if err := setup(mgr, o, s); err != nil {

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -106,6 +106,8 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 				return ctrl.Result{}, err
 			}
+
+			r.log.Info("Failed to get bucket for health check on s3 backend", "name", providerConfig.Name)
 		}
 	}
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -117,6 +117,8 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		err = r.bucketExistsRetry(ctx, providerConfig.Name, hcBucket.Name)
 	})
 	if err != nil {
+		r.onceMap.deleteEntry(providerConfig.Name)
+
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -49,9 +49,6 @@ const (
 	errUpdateHealth       = "failed to update health status of provider config"
 	healthCheckSuffix     = "-health-check"
 	healthCheckFile       = "health-check-file"
-	healthStatusHealthy   = "Healthy"
-	healthStatusUnhealthy = "Unhealthy"
-	healthStatusDisabled  = "HealthCheckDisabled"
 	// retryInterval is the interval used when checking
 	// for an existing bucket.
 	retryInterval        = 5
@@ -93,7 +90,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if providerConfig.Spec.DisableHealthCheck {
-		providerConfig.Status.Health = healthStatusDisabled
+		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled
 		if err := r.kubeClient.Status().Update(ctx, providerConfig); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, errGetHealthCheckFile)
 		}
@@ -189,7 +186,7 @@ func (r *HealthCheckReconciler) doHealthCheck(ctx context.Context, providerConfi
 	}
 
 	// Assume the status is Unhealthy until we can verify otherwise.
-	providerConfig.Status.Health = healthStatusUnhealthy
+	providerConfig.Status.Health = apisv1alpha1.HealthStatusUnhealthy
 
 	_, putErr := s3Backend.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(hcBucket.Name),
@@ -217,7 +214,7 @@ func (r *HealthCheckReconciler) doHealthCheck(ctx context.Context, providerConfi
 	}
 
 	// Health check completed successfully, update status.
-	providerConfig.Status.Health = healthStatusHealthy
+	providerConfig.Status.Health = apisv1alpha1.HealthStatusHealthy
 
 	return r.kubeClient.Status().Update(ctx, providerConfig)
 }

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -103,6 +103,8 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if kerrors.IsNotFound(err) {
 			// No existing health check bucket for this ProviderConfig, create it.
 			if err := r.createHealthCheckBucket(ctx, providerConfig, hcBucket); err != nil {
+				r.log.Info("Failed to create bucket for health check on s3 backend", "name", providerConfig.Name)
+
 				return ctrl.Result{}, err
 			}
 		}

--- a/internal/controller/providerconfig/oncemap.go
+++ b/internal/controller/providerconfig/oncemap.go
@@ -1,0 +1,38 @@
+package providerconfig
+
+import "sync"
+
+// onceMap is used by the health-check controller to ensure
+// initial checks are only carried out once for each backend.
+type onceMap struct {
+	mu      sync.RWMutex
+	onceMap map[string]*sync.Once
+}
+
+func newOnceMap() *onceMap {
+	return &onceMap{
+		onceMap: make(map[string]*sync.Once),
+	}
+}
+
+func (s *onceMap) addEntryWithOnce(backendName string) *sync.Once {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if once, ok := s.onceMap[backendName]; ok {
+		// already exists, return existing.
+		return once
+	}
+
+	once := &sync.Once{}
+	s.onceMap[backendName] = once
+
+	return once
+}
+
+func (s *onceMap) deleteEntry(backendName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.onceMap, backendName)
+}

--- a/internal/controller/providerconfig/setup.go
+++ b/internal/controller/providerconfig/setup.go
@@ -1,0 +1,46 @@
+package providerconfig
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
+	"github.com/linode/provider-ceph/internal/backendstore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Setup adds controllers to reconcile the backend store and backend health.
+func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore) error {
+	name := providerconfig.ControllerName(apisv1alpha1.ProviderConfigGroupKind)
+
+	of := resource.ProviderConfigKinds{
+		Config:    apisv1alpha1.ProviderConfigGroupVersionKind,
+		UsageList: apisv1alpha1.ProviderConfigUsageListGroupVersionKind,
+	}
+
+	// Add an 'internal' controller to the manager for the ProviderConfig.
+	// This will be used to reconcile the backend store.
+	if err := newBackendStoreReconciler(mgr.GetClient(), o, s).setupWithManager(mgr); err != nil {
+		return err
+	}
+
+	// Add an 'internal' controller to the manager for the ProviderConfig.
+	// This will be used to reconcile the health of each backend.
+	if err := newHealthCheckReconciler(mgr.GetClient(), o, s).setupWithManager(mgr); err != nil {
+		return err
+	}
+
+	r := providerconfig.NewReconciler(mgr, of,
+		providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
+		providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		For(&apisv1alpha1.ProviderConfig{}).
+		Watches(&source.Kind{Type: &apisv1alpha1.ProviderConfigUsage{}}, &resource.EnqueueRequestForProviderConfig{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+func RemoveStringFromSlice(slice []string, str string) []string {
+	updated := make([]string, 0)
+	for _, s := range slice {
+		if s != str {
+			updated = append(updated, s)
+		}
+	}
+
+	return updated
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestRemoveStringFromSlice(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		slice []string
+		str   string
+		want  []string
+	}{
+		"Remove single string": {
+			slice: []string{"abc", "def", "ghi"},
+			str:   "abc",
+			want:  []string{"def", "ghi"},
+		},
+		"Remove multiple strings": {
+			slice: []string{"abc", "def", "abc", "ghi", "abc", "jkl", "abc"},
+			str:   "abc",
+			want:  []string{"def", "ghi", "jkl"},
+		},
+		"String does not exist": {
+			slice: []string{"abc", "def", "abc", "ghi", "abc", "jkl"},
+			str:   "xyz",
+			want:  []string{"abc", "def", "abc", "ghi", "abc", "jkl"},
+		},
+		"Single entry found": {
+			slice: []string{"abc"},
+			str:   "abc",
+			want:  []string{},
+		},
+		"Empty slice": {
+			slice: []string{},
+			str:   "abc",
+			want:  []string{},
+		},
+		"Nil slice": {
+			slice: nil,
+			str:   "abc",
+			want:  []string{},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RemoveStringFromSlice(tc.slice, tc.str)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nRemoveStringFromSlice(...): -want, +got:\n%s\n", tc.want, diff)
+			}
+		})
+	}
+}

--- a/package/crds/ceph.crossplane.io_providerconfigs.yaml
+++ b/package/crds/ceph.crossplane.io_providerconfigs.yaml
@@ -155,6 +155,10 @@ spec:
               health:
                 description: Health of the s3 backend represented by the ProviderConfig
                   determined by periodic health check.
+                enum:
+                - Healthy
+                - Unhealthy
+                - HealthCheckDisabled
                 type: string
               users:
                 description: Users of this provider configuration.

--- a/package/crds/ceph.crossplane.io_providerconfigs.yaml
+++ b/package/crds/ceph.crossplane.io_providerconfigs.yaml
@@ -96,6 +96,13 @@ spec:
                 required:
                 - source
                 type: object
+              disableHealthCheck:
+                type: boolean
+              healthCheckIntervalSeconds:
+                default: 30
+                format: int32
+                minimum: 0
+                type: integer
               hostBase:
                 description: HostBase url specified in s3cfg.
                 type: string
@@ -145,6 +152,10 @@ spec:
                   - type
                   type: object
                 type: array
+              health:
+                description: Health of the s3 backend represented by the ProviderConfig
+                  determined by periodic health check.
+                type: string
               users:
                 description: Users of this provider configuration.
                 format: int64


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add reconcile loop to perform health check on s3 backends and update corresponding `ProviderConfig`.
The health check creates a `Bucket` initially. Then performs a `PutObject` and `GetObject` at the specified interval (default 30s) as these operations are less taxing. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Kuttl assertions are updated with health status in CRs
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
