### PR TITLE
Remove OwnershipControls updates

### DIFF
--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -358,20 +358,10 @@ func (c *external) update(ctx context.Context, bucket *v1alpha1.Bucket, s3Backen
 		}
 	}
 
-	if bucket.Spec.ForProvider.ObjectOwnership == nil {
-		_, err := s3Backend.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{
-			Bucket: aws.String(bucket.Name),
-		})
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	_, err := s3Backend.PutBucketOwnershipControls(ctx, s3internal.BucketToPutBucketOwnershipControlsInput(bucket))
-
-	return err
+	//TODO: Add functionality for bucket ownership controls, using s3 apis:
+	// - DeleteBucketOwnershipControls
+	// - PutBucketOwnershipControls
+	return nil
 }
 
 func (c *external) Delete(ctx context.Context, mg resource.Managed) error {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The functionality added for update operation (specifically `DeleteBucketOwnershipControls`) caused an error against Ceph:
```
,"error":"operation error S3: DeleteBucketOwnershipControls, https response error StatusCode: 409, RequestID: tx00000621544e0bc66773e-0064884c1d-1042-default, HostID: 1042-default-default, api error BucketNotEmpty: UnknownError"}
```
As the Update functionality was/is an unnecessary nice-to-have, I'm removing the ownership control API calls altogether to unblock development. Added a TODO to come back and add a proper solution when time permits.

For future reference - the issue did not appear on Localstack.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Kuttl tests with Localstack and manually against Ceph
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
