### PR TITLE
Ensure hc bucket is removed when disabled in cr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/dave/jennifer v1.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -129,12 +130,13 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	return &external{backendStore: c.backendStore.GetBackendStore(), log: c.log}, nil
+	return &external{kubeClient: c.kube, backendStore: c.backendStore.GetBackendStore(), log: c.log}, nil
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
 // external resource to ensure it reflects the managed resource's desired state.
 type external struct {
+	kubeClient   client.Client
 	backendStore *backendstore.BackendStore
 	log          logging.Logger
 }
@@ -223,7 +225,21 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	// Where a bucket has a ProviderConfigReference Name, we can infer that this bucket is to be
 	// created only on this S3 Backend. An empty config reference name will be automatically set
 	// to "default".
-	if bucket.GetProviderConfigReference() != nil && bucket.GetProviderConfigReference().Name != defaultPC {
+	backendName := bucket.GetProviderConfigReference().Name
+	if bucket.GetProviderConfigReference() != nil && backendName != defaultPC {
+		backendName := bucket.GetProviderConfigReference().Name
+
+		pc := &apisv1alpha1.ProviderConfig{}
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: backendName}, pc); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errGetPC)
+		}
+
+		if pc.Spec.DisableHealthCheck {
+			c.log.Info("Health check is disabled on backend - health-check-bucket will not be created", "backend name", backendName)
+
+			return managed.ExternalCreation{}, nil
+		}
+
 		return c.create(ctx, bucket, backends)
 	}
 
@@ -270,11 +286,22 @@ func (c *external) createAll(ctx context.Context, bucket *v1alpha1.Bucket, backe
 	// Create the bucket on each backend in a separate go routine
 	allBackends := c.backendStore.GetAllBackends()
 	for beName := range allBackends {
+		pc := &apisv1alpha1.ProviderConfig{}
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: beName}, pc); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errGetPC)
+		}
+
+		if pc.Spec.DisableHealthCheck {
+			c.log.Info("Health check is disabled on backend - health-check-bucket will not be created", "backend name", beName)
+			continue
+		}
+
 		if !c.backendStore.IsBackendActive(beName) {
 			c.log.Info("Backend is marked inactive - bucket will not be created on backend", "bucket name", bucket.Name, "backend name", beName)
 
 			continue
 		}
+
 		bn := beName
 		cl := c.backendStore.GetBackendClient(beName)
 		if cl == nil {

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -225,8 +225,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	// Where a bucket has a ProviderConfigReference Name, we can infer that this bucket is to be
 	// created only on this S3 Backend. An empty config reference name will be automatically set
 	// to "default".
-	backendName := bucket.GetProviderConfigReference().Name
-	if bucket.GetProviderConfigReference() != nil && backendName != defaultPC {
+	if bucket.GetProviderConfigReference() != nil && bucket.GetProviderConfigReference().Name != defaultPC {
 		backendName := bucket.GetProviderConfigReference().Name
 
 		pc := &apisv1alpha1.ProviderConfig{}
@@ -293,6 +292,7 @@ func (c *external) createAll(ctx context.Context, bucket *v1alpha1.Bucket, backe
 
 		if pc.Spec.DisableHealthCheck {
 			c.log.Info("Health check is disabled on backend - health-check-bucket will not be created", "backend name", beName)
+
 			continue
 		}
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -98,8 +98,8 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		// Delete the bucket directly as cleanup only removes a finalizer.
-		if err := r.kubeClient.Delete(ctx, hcBucket); resource.Ignore(kerrors.IsNotFound, err) != nil {
-			return ctrl.Result{}, err
+		if err := r.kubeClient.Delete(ctx, hcBucket); err != nil {
+			return ctrl.Result{}, resource.Ignore(kerrors.IsNotFound, err)
 		}
 
 		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -97,6 +97,11 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 
+		// Delete the bucket directly as cleanup only removes a finalizer.
+		if err := r.kubeClient.Delete(ctx, hcBucket); resource.Ignore(kerrors.IsNotFound, err) != nil {
+			return ctrl.Result{}, err
+		}
+
 		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled
 		if err := r.kubeClient.Status().Update(ctx, providerConfig); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, errGetHealthCheckFile)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Previously, setting `disableHealthCheck` option on CR was not removing the relevant helath-check bucket.  This PR resolves that.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
