### PR TITLE
Health check bucket garbage collect

### DIFF
--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -443,7 +443,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 
 	if isHealthCheckBucket(bucket) {
-		c.log.Info("Delete is NOOP for health check bucket - delete is performed by health-check-controller", "bucket", bucket.Name)
+		c.log.Info("Delete is NOOP for health check bucket as it is owned by, and garbage collected on deletion of its related providerconfig", "bucket", bucket.Name)
 
 		return nil
 	}

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -73,7 +73,6 @@ type HealthCheckReconciler struct {
 	log          logging.Logger
 }
 
-//nolint:gocyclo,cyclop // Reconcile functions are inherently complex.
 func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.log.Info("Reconciling health of s3 backend", "name", req.Name)
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -93,15 +93,6 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if providerConfig.Spec.DisableHealthCheck {
-		if err := r.cleanup(ctx, req, hcBucket); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		// Delete the bucket directly as cleanup only removes a finalizer.
-		if err := r.kubeClient.Delete(ctx, hcBucket); err != nil {
-			return ctrl.Result{}, resource.Ignore(kerrors.IsNotFound, err)
-		}
-
 		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled
 		if err := r.kubeClient.Status().Update(ctx, providerConfig); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, errGetHealthCheckFile)

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -94,7 +94,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if providerConfig.Spec.DisableHealthCheck {
 		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled
 		if err := r.kubeClient.Status().Update(ctx, providerConfig); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, errGetHealthCheckFile)
+			return ctrl.Result{}, errors.Wrap(err, errUpdateHealth)
 		}
 
 		return ctrl.Result{}, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Apologies, I've gone back and forth on this a bit. But ultimately I'm removing the "manual" deletion of the health-check bucket from the health-check-controller because it plays RBAC havoc.

So the behaviour now is
- The health-check bucket is created whenever a `providerConfig` has its `disableHealthCheck: false` (this is default) and it remains for the lifetime of the `providerConfig`. 
- If `disableHealthCheck: true`, the health check action is not carried out, but the bucket remains.
- The health-check bucket is garbage collected on deletion of the `providerConfig`.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
