### PR TITLE
Incorporate backend health into bucket readiness status

### DIFF
--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -59,7 +59,7 @@ type HealthStatus string
 const (
 	HealthStatusHealthy   = "Healthy"
 	HealthStatusUnhealthy = "Unhealthy"
-	HealthStatusDisabled  = "HealthCheckDisabled"
+	HealthStatusUnknown   = "Unknown"
 )
 
 // A ProviderConfigStatus reflects the observed state of a ProviderConfig.

--- a/internal/backendstore/backend.go
+++ b/internal/backendstore/backend.go
@@ -2,16 +2,19 @@ package backendstore
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/linode/provider-ceph/apis/v1alpha1"
 )
 
 type backend struct {
 	s3Client *s3.Client
 	active   bool
+	health   v1alpha1.HealthStatus
 }
 
-func newBackend(s3Client *s3.Client, active bool) *backend {
+func newBackend(s3Client *s3.Client, active bool, health v1alpha1.HealthStatus) *backend {
 	return &backend{
 		s3Client: s3Client,
 		active:   active,
+		health:   health,
 	}
 }

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -95,7 +95,7 @@ func (b *BackendStore) GetBackendHealthStatus(backendName string) v1alpha1.Healt
 		return b.s3Backends[backendName].health
 	}
 
-	return v1alpha1.HealthStatusUnhealthy
+	return v1alpha1.HealthStatusUnknown
 }
 
 func (b *BackendStore) SetBackendHealthStatus(backendName string, health v1alpha1.HealthStatus) {

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/linode/provider-ceph/apis/v1alpha1"
 )
 
 // s3Backends is a map of S3 backend name (eg ceph cluster name) to backend.
@@ -86,6 +87,26 @@ func (b *BackendStore) ToggleBackendActiveStatus(backendName string, active bool
 	}
 }
 
+func (b *BackendStore) GetBackendHealthStatus(backendName string) v1alpha1.HealthStatus {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if _, ok := b.s3Backends[backendName]; ok {
+		return b.s3Backends[backendName].health
+	}
+
+	return v1alpha1.HealthStatusUnhealthy
+}
+
+func (b *BackendStore) SetBackendHealthStatus(backendName string, health v1alpha1.HealthStatus) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.s3Backends[backendName]; ok {
+		b.s3Backends[backendName].health = health
+	}
+}
+
 func (b *BackendStore) DeleteBackend(backendName string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -93,11 +114,11 @@ func (b *BackendStore) DeleteBackend(backendName string) {
 	delete(b.s3Backends, backendName)
 }
 
-func (b *BackendStore) AddOrUpdateBackend(backendName string, backendClient *s3.Client, active bool) {
+func (b *BackendStore) AddOrUpdateBackend(backendName string, backendClient *s3.Client, active bool, health v1alpha1.HealthStatus) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.s3Backends[backendName] = newBackend(backendClient, active)
+	b.s3Backends[backendName] = newBackend(backendClient, active, health)
 }
 
 func (b *BackendStore) GetBackend(backendName string) *backend {

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -528,9 +528,14 @@ func (c *external) updateAll(ctx context.Context, bucket *v1alpha1.Bucket) error
 
 				err = c.update(ctx, bucket, cl)
 				if err == nil {
-					bucketBackends.setBucketBackendStatus(bucket.Name, beName, v1alpha1.BackendReadyStatus)
+					// Check to see if this backend has been marked as 'Unhealthy'. It may be 'Unknown' due to
+					// the healthcheck being disabled. In which case we can only assume the backend is healthy
+					// and mark the bucket as 'Ready' for this backend.
+					if c.backendStore.GetBackendHealthStatus(beName) == apisv1alpha1.HealthStatusUnhealthy {
+						break
+					}
 
-					break
+					bucketBackends.setBucketBackendStatus(bucket.Name, beName, v1alpha1.BackendReadyStatus)
 				}
 			}
 

--- a/internal/controller/bucket/bucket_test.go
+++ b/internal/controller/bucket/bucket_test.go
@@ -177,7 +177,7 @@ func TestCreate(t *testing.T) {
 			fields: fields{
 				backendStore: func() *backendstore.BackendStore {
 					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-0", nil, false)
+					bs.AddOrUpdateBackend("s3-backend-0", nil, false, apisv1alpha1.HealthStatusUnknown)
 
 					return bs
 				}(),
@@ -197,8 +197,8 @@ func TestCreate(t *testing.T) {
 			fields: fields{
 				backendStore: func() *backendstore.BackendStore {
 					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-0", nil, true)
-					bs.AddOrUpdateBackend("s3-backend-1", nil, false)
+					bs.AddOrUpdateBackend("s3-backend-0", nil, true, apisv1alpha1.HealthStatusUnknown)
+					bs.AddOrUpdateBackend("s3-backend-1", nil, false, apisv1alpha1.HealthStatusUnknown)
 
 					return bs
 				}(),
@@ -218,7 +218,7 @@ func TestCreate(t *testing.T) {
 			fields: fields{
 				backendStore: func() *backendstore.BackendStore {
 					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-0", nil, true)
+					bs.AddOrUpdateBackend("s3-backend-0", nil, true, apisv1alpha1.HealthStatusUnknown)
 
 					return bs
 				}(),

--- a/internal/controller/providerconfig/backendstore_controller.go
+++ b/internal/controller/providerconfig/backendstore_controller.go
@@ -86,7 +86,13 @@ func (r *BackendStoreReconciler) addOrUpdateBackend(ctx context.Context, pc *api
 		return errors.Wrap(err, errCreateClient)
 	}
 
-	r.backendStore.AddOrUpdateBackend(pc.Name, s3client, true)
+	var health apisv1alpha1.HealthStatus
+	health = apisv1alpha1.HealthStatusUnknown
+	if pc.Status.Health != "" {
+		health = pc.Status.Health
+	}
+
+	r.backendStore.AddOrUpdateBackend(pc.Name, s3client, true, health)
 
 	return nil
 }

--- a/internal/controller/providerconfig/backendstore_controller.go
+++ b/internal/controller/providerconfig/backendstore_controller.go
@@ -64,6 +64,7 @@ func (r *BackendStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if kerrors.IsNotFound(err) {
 			r.log.Info("Marking s3 backend as inactive on backend store", "name", req.Name)
 			r.backendStore.ToggleBackendActiveStatus(req.Name, false)
+			r.backendStore.SetBackendHealthStatus(req.Name, apisv1alpha1.HealthStatusUnknown)
 
 			return ctrl.Result{}, nil
 		}

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -95,7 +95,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if providerConfig.Spec.DisableHealthCheck {
 		r.log.Info("Health check is disabled for s3 backend", "name", req.Name)
-		providerConfig.Status.Health = apisv1alpha1.HealthStatusDisabled
+		providerConfig.Status.Health = apisv1alpha1.HealthStatusUnknown
 		if err := r.kubeClient.Status().Update(ctx, providerConfig); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, errUpdateHealth)
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Use the health status of each backend (as determined by the health-check-controller) to make a more informed update to `bucket.Status.AtProvider.Backends`. If the health check has been disabled for any backend, default to original behaviour.
Also changed `HealthCheckDisabled` status to more generic `Unknown` status.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.



<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
