### PR TITLE
Modify GitHub Actions: Image tag auto update

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,14 +13,29 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      MESSAGE: ${{ github.event.inputs.message }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Create Tag
-        uses: negz/create-tag@v1
-        with:
-          version: ${{ github.event.inputs.version }}
-          message: ${{ github.event.inputs.message }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update image tag
+      run: /bin/bash ./hack/update-image-tag.sh $VERSION
+
+    - name: Set git config
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "<>"
+
+    - name: Commit
+      run: |
+        git add .
+        git commit -m "New version: ${VERSION}"
+        git push origin ${GITHUB_REF#refs/heads/}
+
+    - name: Tag
+      run: |
+        git tag $VERSION -m "$MESSAGE"
+        git push origin $VERSION

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ guide may also be of use.
 Install the provider by using the Upbound CLI after changing the image tag to the latest release:
 
 ```
-up ctp provider install linode/provider-ceph:v0.0.13
+up ctp provider install linode/provider-ceph:v0.0.14
 ```
 
 Alternatively, you can use declarative installation:
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: linode-provider-ceph
 spec:
-  package: xpkg.upbound.io/linode/provider-ceph:v0.0.13
+  package: xpkg.upbound.io/linode/provider-ceph:v0.0.14
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ guide may also be of use.
 Install the provider by using the Upbound CLI after changing the image tag to the latest release:
 
 ```
-up ctp provider install linode/provider-ceph:v0.0.8
+up ctp provider install linode/provider-ceph:v0.0.13
 ```
 
 Alternatively, you can use declarative installation:
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: linode-provider-ceph
 spec:
-  package: xpkg.upbound.io/linode/provider-ceph:v0.0.8
+  package: xpkg.upbound.io/linode/provider-ceph:v0.0.13
 EOF
 ```
 

--- a/hack/update-image-tag.sh
+++ b/hack/update-image-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+VERSION=${1:?}
+IMAGE=${2:-linode/provider-ceph}
+
+for file in "package/crossplane.yaml" "README.md"
+do
+    sed -E -i \
+        "s|${IMAGE}:(.*)|${IMAGE}:${VERSION}|g" \
+        $file
+done

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -12,4 +12,4 @@ metadata:
     friendly-name.meta.crossplane.io: Provider Ceph
 spec:
   controller:
-    image: xpkg.upbound.io/linode/provider-ceph:v0.0.1
+    image: xpkg.upbound.io/linode/provider-ceph:v0.0.13

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -12,4 +12,4 @@ metadata:
     friendly-name.meta.crossplane.io: Provider Ceph
 spec:
   controller:
-    image: xpkg.upbound.io/linode/provider-ceph:v0.0.13
+    image: xpkg.upbound.io/linode/provider-ceph:v0.0.14


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Currently we should change versions (image tags) in package/crossplane.yaml and README manually before kicking `Tag` workflow.

This PR is updating the action to replace these versions.

### How the modified Tag workflow works
1. Kick the workflow with version and message, and main branch
2. Workflow do:
    1. Replace versions in file
    2. Push the changes to the remote main branch
    3.  Create/push a new tag from the latest main branch

### How has this code been tested
Nothing, but I emulated the (almost) same script on my test repository: https://github.com/Shunpoco/trial-github-actions-tag