### PR TITLE
Add creation grace period flag

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -70,6 +70,7 @@ func main() {
 		reconcileConcurrency = app.Flag("reconcile-concurrency", "Set number of reconciliation loops.").Default("100").Int()
 		maxReconcileRate     = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("1000").Int()
 		reconcileTimeout     = app.Flag("reconcile-timeout", "Object reconciliation timeout").Short('t').Default("3s").Duration()
+		creationGracePeriod  = app.Flag("creation-grace-period", "Duration to wait for the external API to report that a newly created external resource exists.").Default("10s").Duration()
 
 		kubeClientRate = app.Flag("kube-client-rate", "The global maximum rate per second at how many requests the client can do.").Default("1000").Int()
 
@@ -215,6 +216,6 @@ func main() {
 			Complete(), "Cannot setup bucket validating webhook")
 	}
 
-	kingpin.FatalIfError(ceph.Setup(mgr, o, backendStore, *autoPauseBucket, *pollInterval, *reconcileTimeout), "Cannot setup Ceph controllers")
+	kingpin.FatalIfError(ceph.Setup(mgr, o, backendStore, *autoPauseBucket, *pollInterval, *reconcileTimeout, *creationGracePeriod), "Cannot setup Ceph controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -72,7 +72,7 @@ var (
 )
 
 // Setup adds a controller that reconciles Bucket managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, autoPauseBucket bool, pollInterval, operationTimeout time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, autoPauseBucket bool, pollInterval, operationTimeout, creationGracePeriod time.Duration) error {
 	name := managed.ControllerName(v1alpha1.BucketGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
@@ -96,6 +96,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore,
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithCreationGracePeriod(creationGracePeriod),
 	}
 
 	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {

--- a/internal/controller/ceph.go
+++ b/internal/controller/ceph.go
@@ -29,12 +29,12 @@ import (
 
 // Setup creates all Ceph controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, a bool, p, t time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, a bool, p, t, cgp time.Duration) error {
 	if err := providerconfig.Setup(mgr, o, s); err != nil {
 		return err
 	}
 
-	if err := bucket.Setup(mgr, o, s, a, p, t); err != nil {
+	if err := bucket.Setup(mgr, o, s, a, p, t, cgp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add flag to make creation grace period configurable. By default it is 30s - this means that a managed resource cannot be deleted within 30s of its creation time. Reducing this to 10s to reduce likelihood of deleted CRs hanging. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing tests pass (a little bit quicker :sunglasses: )
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
