### PR TITLE
Introduce cache for S3 HeadBucket calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ load-package: $(KIND) build
 	@$(MAKE) local.xpkg.sync
 	@$(INFO) deploying provider package $(PROJECT_NAME)
 	@$(KIND) load docker-image $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH) -n $(KIND_CLUSTER_NAME)
-	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["--zap-devel","--enable-validation-webhooks", "--kube-client-rate=100000", "--reconcile-timeout=2s", "--max-reconcile-rate=5000", "--reconcile-concurrency=100", "--poll=30m", "--sync=1h"],"image":"$(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH)"}}' | $(KUBECTL) apply -f -
+	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["--zap-devel", "--enable-validation-webhooks", "--kube-client-rate=80000", "--reconcile-timeout=5s", "--max-reconcile-rate=600", "--reconcile-concurrency=160", "--poll=30m", "--sync=1h"],"image":"$(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH)"}}' | $(KUBECTL) apply -f -
 	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$(PROJECT_NAME)"},"spec":{"package":"$(PROJECT_NAME)-$(VERSION).gz","packagePullPolicy":"Never","controllerConfigRef":{"name":"config"}}}' | $(KUBECTL) apply -f -
 	@$(OK) deploying provider package $(PROJECT_NAME) $(VERSION)
 

--- a/e2e/kind/kind-config-1.25.yaml
+++ b/e2e/kind/kind-config-1.25.yaml
@@ -10,3 +10,10 @@ nodes:
     hostPort: 32567
   - containerPort: 32568
     hostPort: 32568
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          max-mutating-requests-inflight: "2000"
+          max-requests-inflight: "4000"

--- a/e2e/kind/kind-config-1.26.yaml
+++ b/e2e/kind/kind-config-1.26.yaml
@@ -10,3 +10,10 @@ nodes:
     hostPort: 32567
   - containerPort: 32568
     hostPort: 32568
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          max-mutating-requests-inflight: "2000"
+          max-requests-inflight: "4000"

--- a/e2e/kind/kind-config-1.27.yaml
+++ b/e2e/kind/kind-config-1.27.yaml
@@ -10,3 +10,10 @@ nodes:
     hostPort: 32567
   - containerPort: 32568
     hostPort: 32568
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          max-mutating-requests-inflight: "2000"
+          max-requests-inflight: "4000"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/linode/provider-ceph
 go 1.20
 
 require (
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/aws/aws-sdk-go-v2 v1.20.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.34
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.33

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go-v2 v1.20.2 h1:0Aok9u/HVTk7RtY6M1KDcthbaMKGhhS0eLPxIdSIzRI=
 github.com/aws/aws-sdk-go-v2 v1.20.2/go.mod h1:NU06lETsFm8fUC6ZjhgDpVBcGZTFQ6XM+LZWZxMI4ac=

--- a/hack/generate-tests.sh
+++ b/hack/generate-tests.sh
@@ -37,6 +37,13 @@ nodes:
     hostPort: 32567
   - containerPort: 32568
     hostPort: 32568
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          max-mutating-requests-inflight: "2000"
+          max-requests-inflight: "4000"
 EOF
 	# write kuttl config file for version
 	if [ ! -d "./e2e/kuttl/ceph" ]; then

--- a/internal/controller/bucket/bucket_test.go
+++ b/internal/controller/bucket/bucket_test.go
@@ -275,6 +275,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket-check-external-error",
 						Finalizers: []string{inUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{
@@ -327,6 +328,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket-check-external-not-exists",
 						Finalizers: []string{inUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{
@@ -379,6 +381,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket-check-external-ok",
 						Finalizers: []string{inUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -85,8 +85,8 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 			var err error
 
 			for i := 0; i < s3internal.RequestRetries; i++ {
-				_, err = cl.CreateBucket(ctx, s3internal.BucketToCreateBucketInput(originalBucket))
-				if resource.Ignore(isAlreadyExists, err) == nil {
+				_, err = s3internal.CreateBucket(ctx, cl, s3internal.BucketToCreateBucketInput(originalBucket))
+				if resource.Ignore(s3internal.IsAlreadyExists, err) == nil {
 					break
 				}
 			}

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -4,23 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
-	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
-
-// isAlreadyExists helper function to test for ErrCodeBucketAlreadyOwnedByYou error
-func isAlreadyExists(err error) bool {
-	var alreadyOwnedByYou *s3types.BucketAlreadyOwnedByYou
-
-	return errors.As(err, &alreadyOwnedByYou)
-}
 
 func setBucketStatus(bucket *v1alpha1.Bucket, bucketBackends *bucketBackends) {
 	bucket.Status.SetConditions(xpv1.Unavailable())

--- a/internal/s3/cache/cache.go
+++ b/internal/s3/cache/cache.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/allegro/bigcache/v3"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	BucketExistsCacheTTL = time.Duration(0)
+
+	bucketExistsCache      *bigcache.BigCache
+	bucketExistsCacheEntry = make([]byte, 0)
+	bucketExistsCacheInit  = sync.Once{}
+)
+
+func bucketExistsCacheInitFunc() {
+	config := bigcache.DefaultConfig(BucketExistsCacheTTL)
+	config.MaxEntrySize = 0
+	config.Verbose = false
+	config.Logger = nil
+
+	var err error
+	bucketExistsCache, err = bigcache.New(context.Background(), config)
+	kingpin.FatalIfError(err, "Cannot create S3 bucket exists client cache")
+}
+
+func Exists(key string) bool {
+	bucketExistsCacheInit.Do(bucketExistsCacheInitFunc)
+
+	_, err := bucketExistsCache.Get(key)
+
+	return err == nil
+}
+
+func Set(key string) {
+	bucketExistsCacheInit.Do(bucketExistsCacheInitFunc)
+
+	err := bucketExistsCache.Set(key, bucketExistsCacheEntry)
+	if err != nil {
+		kingpin.Errorf("failed to set bucket exists cache entry: %w", err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change introduces a cache for S3 HeadBucket calls. With this cache Observe and Upgrade reconciliation loops don't need to ask backend for bucket existance. During the stress test i have found stable configuration for the controller and Kube api server.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I did stress testing and excuted e2e tests.

[contribution process]: https://git.io/fj2m9
