### PR TITLE
Save reason of failed healthcheck

### DIFF
--- a/apis/provider-ceph/v1alpha1/utils.go
+++ b/apis/provider-ceph/v1alpha1/utils.go
@@ -21,6 +21,8 @@ const (
 	HealthCheckLabelVal = "health-check-bucket"
 )
 
+// Deprecation warning: This function exists for compatibility reasons,
+// and would be removed soon.
 func IsHealthCheckBucket(bucket *Bucket) bool {
 	if val, ok := bucket.GetLabels()[HealthCheckLabelKey]; ok {
 		if val == HealthCheckLabelVal {

--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -69,6 +69,7 @@ type ProviderConfigStatus struct {
 	// by periodic health check.
 	// +kubebuilder:validation:Enum=Healthy;Unhealthy;Unknown
 	Health                    HealthStatus `json:"health,omitempty"`
+	Reason                    string       `json:"reason,omitempty"`
 	xpv1.ProviderConfigStatus `json:",inline"`
 }
 

--- a/e2e/localstack/localstack-provider-cfg-host.yaml
+++ b/e2e/localstack/localstack-provider-cfg-host.yaml
@@ -2,7 +2,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-a
-  namespace: crossplane-system
 spec:
   hostBase: "0.0.0.0:32566"
   credentials:
@@ -17,7 +16,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-b
-  namespace: crossplane-system
 spec:
   hostBase: "0.0.0.0:32567"
   credentials:
@@ -32,7 +30,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-c
-  namespace: crossplane-system
 spec:
   hostBase: "0.0.0.0:32568"
   credentials:

--- a/e2e/localstack/localstack-provider-cfg.yaml
+++ b/e2e/localstack/localstack-provider-cfg.yaml
@@ -2,7 +2,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-a
-  namespace: crossplane-system
 spec:
   hostBase: "localstack-a:32566"
   credentials:
@@ -18,7 +17,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-b
-  namespace: crossplane-system
 spec:
   hostBase: "localstack-b:32567"
   credentials:
@@ -34,7 +32,6 @@ apiVersion: ceph.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: localstack-c
-  namespace: crossplane-system
 spec:
   hostBase: "localstack-c:32568"
   credentials:

--- a/e2e/tests/stable/provider-ceph/99-health-check-bucket-check.yaml
+++ b/e2e/tests/stable/provider-ceph/99-health-check-bucket-check.yaml
@@ -1,7 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: sleep 10 # Wait for reconciliation of health check buckets based on interval.
+  - command: sleep 8 # Wait for reconciliation of health check buckets based on interval.
   - command: ../../../../hack/expect_bucket.sh bucket_does_not_exist localstack-a-health-check local-dev-control-plane:32566
   - command: ../../../../hack/expect_bucket.sh bucket_does_not_exist localstack-b-health-check local-dev-control-plane:32567
   - command: ../../../../hack/expect_bucket.sh bucket_does_not_exist localstack-c-health-check local-dev-control-plane:32568

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -2,11 +2,11 @@ package bucket
 
 import (
 	"context"
-	"fmt"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
+	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -76,7 +76,7 @@ func (c *external) updateObject(ctx context.Context, bucket *v1alpha1.Bucket, ca
 				break
 			}
 
-			return fmt.Errorf("unable to update object: %w", err)
+			return errors.Wrap(err, "unable to update object")
 		}
 	}
 

--- a/package/crds/ceph.crossplane.io_providerconfigs.yaml
+++ b/package/crds/ceph.crossplane.io_providerconfigs.yaml
@@ -159,6 +159,8 @@ spec:
                 - Unhealthy
                 - Unknown
                 type: string
+              reason:
+                type: string
               users:
                 description: Users of this provider configuration.
                 format: int64


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change saves the reason of failed health check. corev1.Event is namespaced object, so this is the only option to record failure.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
