### PR TITLE
Document helthcheck requeue after concurrency

### DIFF
--- a/internal/controller/providerconfig/backendstore_controller.go
+++ b/internal/controller/providerconfig/backendstore_controller.go
@@ -45,14 +45,14 @@ const (
 
 func newBackendStoreReconciler(k client.Client, o controller.Options, s *backendstore.BackendStore) *BackendStoreReconciler {
 	return &BackendStoreReconciler{
-		kube:         k,
+		kubeClient:   k,
 		backendStore: s,
 		log:          o.Logger.WithValues("backend-store-controller", providerconfig.ControllerName(apisv1alpha1.ProviderConfigGroupKind)),
 	}
 }
 
 type BackendStoreReconciler struct {
-	kube         client.Client
+	kubeClient   client.Client
 	backendStore *backendstore.BackendStore
 	log          logging.Logger
 }
@@ -60,7 +60,7 @@ type BackendStoreReconciler struct {
 func (r *BackendStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.log.Info("Reconciling backend store", "name", req.Name)
 	providerConfig := &apisv1alpha1.ProviderConfig{}
-	if err := r.kube.Get(ctx, req.NamespacedName, providerConfig); err != nil {
+	if err := r.kubeClient.Get(ctx, req.NamespacedName, providerConfig); err != nil {
 		if kerrors.IsNotFound(err) {
 			r.log.Info("Marking s3 backend as inactive on backend store", "name", req.Name)
 			r.backendStore.ToggleBackendActiveStatus(req.Name, false)
@@ -101,7 +101,7 @@ func (r *BackendStoreReconciler) addOrUpdateBackend(ctx context.Context, pc *api
 func (r *BackendStoreReconciler) getProviderConfigSecret(ctx context.Context, secretNamespace, secretName string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	ns := types.NamespacedName{Namespace: secretNamespace, Name: secretName}
-	if err := r.kube.Get(ctx, ns, secret); err != nil {
+	if err := r.kubeClient.Get(ctx, ns, secret); err != nil {
 		return nil, errors.Wrap(err, "cannot get provider secret")
 	}
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -126,7 +126,9 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return
 	}
 
-	// health check interval is 30s by default.
+	// Health check interval is 30s by default.
+	// It is safe to requeue after the same object multiple times,
+	// because controller runtime reconcilies only once.
 	res = ctrl.Result{
 		RequeueAfter: time.Duration(providerConfig.Spec.HealthCheckIntervalSeconds) * time.Second,
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The provider re-queues every object without without taking care of concurrency. But this is the right behavior because controller runtime takes care on it.

Here is my regular helathchecks:
```
{"level":"info","ts":"2023-10-05T10:16:40.855881071+02:00","logger":"provider-ceph","msg":"Reconciling health of s3 backend","health-check-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
```

Then I edited the provider config:
```
{"level":"info","ts":"2023-10-05T10:16:58.949060929+02:00","logger":"provider-ceph","msg":"Reconciling health of s3 backend","health-check-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
{"level":"info","ts":"2023-10-05T10:16:58.949171162+02:00","logger":"provider-ceph","msg":"Reconciling backend store","backend-store-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
```

This edit din't generate any extra loops.
```
{"level":"info","ts":"2023-10-05T10:17:10.891152276+02:00","logger":"provider-ceph","msg":"Reconciling health of s3 backend","health-check-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
{"level":"info","ts":"2023-10-05T10:17:40.935369216+02:00","logger":"provider-ceph","msg":"Reconciling health of s3 backend","health-check-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
{"level":"info","ts":"2023-10-05T10:18:10.975600551+02:00","logger":"provider-ceph","msg":"Reconciling health of s3 backend","health-check-controller":"providerconfig/providerconfig.ceph.crossplane.io","name":"localstack-a"}
```

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9
