### PR TITLE
Fix bugs related to unpause

### DIFF
--- a/internal/controller/ceph.go
+++ b/internal/controller/ceph.go
@@ -30,7 +30,7 @@ import (
 // Setup creates all Ceph controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, a bool, p, t, cgp time.Duration) error {
-	if err := providerconfig.Setup(mgr, o, s); err != nil {
+	if err := providerconfig.Setup(mgr, o, s, a); err != nil {
 		return err
 	}
 

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -96,6 +96,9 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return
 	}
 
+	// Keep the previous health status to compare the current one later
+	previousHealth := providerConfig.Status.Health
+
 	// Assume the status is Unhealthy until we can verify otherwise.
 	providerConfig.Status.Health = apisv1alpha1.HealthStatusUnhealthy
 	providerConfig.Status.Reason = ""
@@ -119,8 +122,6 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return
 		}
 	}
-
-	previousHealth := providerConfig.Status.Health
 
 	if err = r.doHealthCheck(ctx, providerConfig, bucketName); err != nil {
 		r.log.Info("Failed to do health check on s3 backend", "name", providerConfig.Name, "backend", req.Name)

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -270,7 +270,7 @@ func (r *HealthCheckReconciler) setupWithManager(mgr ctrl.Manager) error {
 func (r *HealthCheckReconciler) unpauseBuckets(ctx context.Context, s3BackendName string) {
 	const (
 		steps    = 4
-		duration = 10 * time.Microsecond
+		duration = 10 * time.Millisecond
 		factor   = 5
 		jitter   = 0.1
 	)

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -291,26 +291,26 @@ func (r *HealthCheckReconciler) unpauseBuckets(ctx context.Context, s3BackendNam
 		return
 	}
 
-	for _, bucket := range buckets.Items {
-		bucket := bucket
-		r.log.Debug("unpause bucket", "bucket", bucket.Name)
+	for i := range buckets.Items {
+		i := i
+		r.log.Debug("unpause bucket", "bucket", buckets.Items[i].Name)
 		err := retry.OnError(wait.Backoff{
 			Steps:    steps,
 			Duration: duration,
 			Factor:   factor,
 			Jitter:   jitter,
 		}, resource.IsAPIError, func() error {
-			if !v1alpha1.IsHealthCheckBucket(&bucket) && bucket.Annotations[meta.AnnotationKeyReconciliationPaused] == "true" {
-				bucket.Annotations[meta.AnnotationKeyReconciliationPaused] = ""
+			if !v1alpha1.IsHealthCheckBucket(&buckets.Items[i]) && buckets.Items[i].Annotations[meta.AnnotationKeyReconciliationPaused] == "true" {
+				buckets.Items[i].Annotations[meta.AnnotationKeyReconciliationPaused] = ""
 
-				return r.kubeClient.Update(ctx, &bucket)
+				return r.kubeClient.Update(ctx, &buckets.Items[i])
 			}
 
 			return nil
 		})
 
 		if err != nil {
-			r.log.Info(err.Error(), "bucket", bucket.Name)
+			r.log.Info(err.Error(), "bucket", buckets.Items[i].Name)
 		}
 	}
 }

--- a/internal/controller/providerconfig/setup.go
+++ b/internal/controller/providerconfig/setup.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup adds controllers to reconcile the backend store and backend health.
-func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore) error {
+func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore, a bool) error {
 	name := providerconfig.ControllerName(apisv1alpha1.ProviderConfigGroupKind)
 
 	of := resource.ProviderConfigKinds{
@@ -28,7 +28,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore)
 
 	// Add an 'internal' controller to the manager for the ProviderConfig.
 	// This will be used to reconcile the health of each backend.
-	if err := newHealthCheckReconciler(mgr.GetClient(), o, s).setupWithManager(mgr); err != nil {
+	if err := newHealthCheckReconciler(mgr.GetClient(), o, s, a).setupWithManager(mgr); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
In #65 , we introduced unpause bucket when a backend comes online again.
However, there are some problems:
- previousHealth is defined after the object health is set as unknown. It causes unnecessary unpause
- Multiple Bucket objects are deep-copied. It will cause huge memory/CPU consumption.
- Retry duration is mis-configured
- We should check global auto pause flag and bucket spec in order to avoid unpause bucket which an user explicitly set unpause flag

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Deploy this provider on the local cluster, and check the behaviour
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
