### PR TITLE
Cache only relevant objects with timeout config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ load-package: $(KIND) build
 	@$(MAKE) local.xpkg.sync
 	@$(INFO) deploying provider package $(PROJECT_NAME)
 	@$(KIND) load docker-image $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH) -n $(KIND_CLUSTER_NAME)
-	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["--zap-devel", "--enable-validation-webhooks", "--kube-client-rate=80000", "--reconcile-timeout=5s", "--max-reconcile-rate=600", "--reconcile-concurrency=160", "--poll=30m", "--sync=1h"],"image":"$(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH)"}}' | $(KUBECTL) apply -f -
+	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["--zap-devel", "--kube-client-rate=80000", "--reconcile-timeout=5s", "--max-reconcile-rate=600", "--reconcile-concurrency=160", "--poll=30m", "--sync=1h"],"image":"$(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH)"}}' | $(KUBECTL) apply -f -
 	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$(PROJECT_NAME)"},"spec":{"package":"$(PROJECT_NAME)-$(VERSION).gz","packagePullPolicy":"Never","controllerConfigRef":{"name":"config"}}}' | $(KUBECTL) apply -f -
 	@$(OK) deploying provider package $(PROJECT_NAME) $(VERSION)
 

--- a/apis/provider-ceph/v1alpha1/bucket_types.go
+++ b/apis/provider-ceph/v1alpha1/bucket_types.go
@@ -113,7 +113,7 @@ type BucketSpec struct {
 	// +optional
 	// Providers is a list of ProviderConfig names representing
 	// S3 backends on which the bucket is to be created.
-	Providers   []string         `json:"providers"`
+	Providers   []string         `json:"providers,omitempty"`
 	ForProvider BucketParameters `json:"forProvider"`
 	// Disabled allows the user to create a Bucket CR without creating
 	// buckets on any S3 backends. If an existing bucket CR is updated

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -2,35 +2,17 @@
 
 ## Enable Webhooks
 - Webhooks are enabled in Crossplane by default from `v1.13` onwards. For previous versions of Crossplane, include the flag `--set webhooks.enabled=true` when [installing Crossplane via Helm](https://docs.crossplane.io/v1.11/software/install/#install-the-crossplane-helm-chart).
-- To enable webhooks in Provider Ceph, set the `--enable-validation-webhooks` flag for the Provider Ceph controller. See example below using a controller configuration:
-
-`Provider` with reference to a `ControllerConfig` (**Note:** package version is omitted):
-```
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-ceph
-spec:
-  package: xpkg.upbound.io/linode/provider-ceph:vX.X.X
-  controllerConfigRef:
-    name: provider-ceph
-```
-`ControllerConfig` with arguments:
-```
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
-metadata:
-  name: provider-ceph
-spec:
-  args:
-  - "--enable-validation-webhooks"
-```
-**Note:** `ControllerConfig` has been deprecated, but remains in use until an alternative exists.
 
 ## Bucket Admission Controlling Webhook
 Provider Ceph provides Dynamic Admission Control for Buckets.
+
+### Bucket Validation Webhook
 Create and Update operations on Buckets are blocked by the bucket admission webhook when:
 - The Bucket contains one or more providers (`bucket.spec.Providers`) that do not exist (i.e. a `ProviderConfig` of the same name does not exist in the k8s cluster).
 
+### Bucket Defaulter Webhook
+During an upgrade of bucket defaulter webhook copies the Crossplane pause annotation value as labels. It blocks bucket creation on any case of failure.
+
+### Bucket Lifecycle Configurations
 Future Work (not yet implemented):
 - Bucket Lifecycle Configurations cannot be validated against a backend.

--- a/e2e/tests/stable/provider-ceph/02-assert.yaml
+++ b/e2e/tests/stable/provider-ceph/02-assert.yaml
@@ -34,6 +34,8 @@ metadata:
   - "bucket-in-use.provider-ceph.crossplane.io"
   annotations:
     crossplane.io/paused: "true"
+  labels:
+    crossplane.io/paused: "true"
 status:
   atProvider:
     backends:
@@ -47,6 +49,6 @@ status:
   - reason: Available
     status: "True"
     type: Ready
-  - reason: ReconcilePaused
-    status: "False"
+  - reason: ReconcileSuccess
+    status: "True"
     type: Synced

--- a/internal/controller/bucket/bucket_mutation_webhook.go
+++ b/internal/controller/bucket/bucket_mutation_webhook.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type BucketMutator struct{}
+
+func NewBucketMutator() *BucketMutator {
+	return &BucketMutator{}
+}
+
+//+kubebuilder:webhook:path=/mutate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket,mutating=true,failurePolicy=fail,sideEffects=None,groups=provider-ceph.ceph.crossplane.io,resources=buckets,verbs=update,versions=v1alpha1,name=bucket-mutation.providerceph.crossplane.io,admissionReviewVersions=v1
+
+func (b *BucketMutator) Default(ctx context.Context, obj runtime.Object) error {
+	bucket, ok := obj.(*v1alpha1.Bucket)
+	if !ok {
+		return errors.New(errNotBucket)
+	}
+
+	if bucket.Labels == nil {
+		bucket.Labels = map[string]string{}
+	}
+
+	bucket.Labels[meta.AnnotationKeyReconciliationPaused] = bucket.Annotations[meta.AnnotationKeyReconciliationPaused]
+
+	return nil
+}

--- a/internal/controller/bucket/bucket_validation_webhook.go
+++ b/internal/controller/bucket/bucket_validation_webhook.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/webhook"
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	s3internal "github.com/linode/provider-ceph/internal/s3"
@@ -34,25 +33,18 @@ import (
 const errValidatingLifecycleConfig = "unable to validate lifecycle configuration"
 
 type BucketValidator struct {
-	validator    *webhook.Validator
 	backendStore *backendstore.BackendStore
 }
 
 func NewBucketValidator(b *backendstore.BackendStore) *BucketValidator {
-	bucketValidator := &BucketValidator{}
-	validator := webhook.NewValidator()
-
-	validator.CreationChain = append(validator.CreationChain, bucketValidator.ValidateCreate)
-	validator.UpdateChain = append(validator.UpdateChain, bucketValidator.ValidateUpdate)
-	validator.DeletionChain = append(validator.DeletionChain, bucketValidator.ValidateDelete)
-
-	bucketValidator.validator = validator
-	bucketValidator.backendStore = b
+	bucketValidator := &BucketValidator{
+		backendStore: b,
+	}
 
 	return bucketValidator
 }
 
-//+kubebuilder:webhook:path=/validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket,mutating=false,failurePolicy=fail,sideEffects=None,groups=provider-ceph.ceph.crossplane.io,resources=buckets,verbs=create;update,versions=v1alpha1,name=bucket.providerceph.crossplane.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket,mutating=false,failurePolicy=fail,sideEffects=None,groups=provider-ceph.ceph.crossplane.io,resources=buckets,verbs=create;update,versions=v1alpha1,name=bucket-validation.providerceph.crossplane.io,admissionReviewVersions=v1
 
 func (b *BucketValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	bucket, ok := obj.(*v1alpha1.Bucket)

--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -1,5 +1,30 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
+  failurePolicy: Fail
+  name: bucket-mutation.providerceph.crossplane.io
+  rules:
+  - apiGroups:
+    - provider-ceph.ceph.crossplane.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    resources:
+    - buckets
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
@@ -12,7 +37,7 @@ webhooks:
       namespace: system
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
   failurePolicy: Fail
-  name: bucket.providerceph.crossplane.io
+  name: bucket-validation.providerceph.crossplane.io
   rules:
   - apiGroups:
     - provider-ceph.ceph.crossplane.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change decreases the size of the cache by not caching paused buckets.
Webhooks are not optional any more.
Timeout of cache is configurable.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
E2E test passes

[contribution process]: https://git.io/fj2m9
