### PR TITLE
Skip validation for deleted buckets

### DIFF
--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -11,7 +11,8 @@ Create and Update operations on Buckets are blocked by the bucket admission webh
 - The Bucket contains one or more providers (`bucket.spec.Providers`) that do not exist (i.e. a `ProviderConfig` of the same name does not exist in the k8s cluster).
 
 ### Bucket Defaulter Webhook
-During an upgrade of bucket defaulter webhook copies the Crossplane pause annotation value as labels. It blocks bucket creation on any case of failure.
+During a Bucket Update, the defaulter webhook replicates the Bucket's pause annotation as a label and adds it to to the Bucket metadata.
+This enables Provider Ceph to cache Buckets objects by label (i.e. only caching Bucket objects which haven't been paused). This webhook will block the Update on any failed case.
 
 ### Bucket Lifecycle Configurations
 Future Work (not yet implemented):

--- a/internal/controller/bucket/bucket_validation_webhook.go
+++ b/internal/controller/bucket/bucket_validation_webhook.go
@@ -61,6 +61,10 @@ func (b *BucketValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		return nil, errors.New(errNotBucket)
 	}
 
+	if bucket.ObjectMeta.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
 	return nil, b.validateCreateOrUpdate(ctx, bucket)
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Skip validation for deleted buckets, otherwise we should face with this error during for example Kuttl cleanup:

```
cannot update object: admission webhook "bucket-validation.providerceph.crossplane.io" denied the request: providers [localstack-b] listed in bucket.Spec.Providers cannot be found'  
```

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

E2E tests passed and there was no buckets after the cleanup.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
