### PR TITLE
Add objectSelector to validating webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ XPKGS = provider-ceph
 -include build/makelib/xpkg.mk
 -include build/makelib/local.xpkg.mk
 
+VAL_WBHK_STAGE ?= $(ROOT_DIR)/staging/validatingwebhookconfiguration
+
 # NOTE(hasheddan): we force image building to happen prior to xpkg build so that
 # we ensure image is present in daemon.
 xpkg.build.provider-ceph: do.build.images
@@ -128,13 +130,22 @@ crossplane-cluster: $(HELM3) cluster
 	@$(HELM3) install crossplane --namespace crossplane-system --create-namespace crossplane-stable/crossplane
 	@$(OK) Installing Crossplane
 
+# Generate the provider-ceph package and webhookconfiguration manifest.
+generate-pkg: generate kustomize-webhook
+
+# Kustomize the webhookconfiguration manifest that is created by 'generate' target.
+kustomize-webhook: $(KUSTOMIZE)
+	@cp $(XPKG_DIR)/webhookconfigurations/manifests.yaml $(VAL_WBHK_STAGE)
+	@$(KUSTOMIZE) build $(VAL_WBHK_STAGE) -o $(XPKG_DIR)/webhookconfigurations/manifests.yaml
+	@ rm $(VAL_WBHK_STAGE)/manifests.yaml
+
 # Build the controller image and the provider package.
 # Load the controller image to the Kind cluster and add the provider package
 # to the Provider.
 # The following is taken from local.xpkg.deploy.provider.
 # However, it is modified to use the "--zap-devel" flag instead of "-d" which does
 # not exist in this project and would therefore cause the controller to CrashLoop.
-load-package: $(KIND) build
+load-package: $(KIND) build kustomize-webhook
 	@$(MAKE) local.xpkg.sync
 	@$(INFO) deploying provider package $(PROJECT_NAME)
 	@$(KIND) load docker-image $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(ARCH) -n $(KIND_CLUSTER_NAME)
@@ -233,9 +244,11 @@ provider.addtype: $(GOMPLATE)
 	@PROVIDER=$(provider) GROUP=$(group) KIND=$(kind) APIVERSION=$(apiversion) ./hack/helpers/addtype.sh
 
 define CROSSPLANE_MAKE_HELP
+
 Crossplane Targets:
-    submodules            Update the submodules, such as the common build scripts.
-    run                   Run crossplane locally, out-of-cluster. Useful for development.
+    submodules      Update the submodules, such as the common build scripts.
+    run             Run crossplane locally, out-of-cluster. Useful for development.
+    generate-pkg    Generate the provider-ceph package and webhook configuration manifest.
 
 endef
 # The reason CROSSPLANE_MAKE_HELP is used instead of CROSSPLANE_HELP is because the crossplane

--- a/apis/provider-ceph/v1alpha1/bucket_types.go
+++ b/apis/provider-ceph/v1alpha1/bucket_types.go
@@ -99,6 +99,8 @@ const (
 	NotReadyStatus Status = "NotReady"
 	DeletingStatus Status = "Deleting"
 	NoStatus       Status = ""
+
+	ValidationRequiredLabel = "provider-ceph.crossplane.io/validation-required"
 )
 
 // BucketObservation are the observable fields of a Bucket.

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -7,9 +7,10 @@
 Provider Ceph provides Dynamic Admission Control for Buckets.
 
 ### Bucket Validation Webhook
+Validates Bucket CRs for Create and Update operations.
+This webhook is also configured with an `objectSelector` label `provider-ceph.crossplane.io/validation-required: true`.
+It is the responsibility of the user (or the external system) to ensure that incoming Bucket CRs are given this label to enable webhook validation, should validation for the CR be desired.
+
 Create and Update operations on Buckets are blocked by the bucket admission webhook when:
 - The Bucket contains one or more providers (`bucket.spec.Providers`) that do not exist (i.e. a `ProviderConfig` of the same name does not exist in the k8s cluster).
-
-### Bucket Lifecycle Configurations
-Future Work (not yet implemented):
 - Bucket Lifecycle Configurations cannot be validated against a backend.

--- a/e2e/tests/ceph/provider-ceph/04-test-bucket.yaml
+++ b/e2e/tests/ceph/provider-ceph/04-test-bucket.yaml
@@ -2,6 +2,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: test-bucket
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   providers:
   - ceph-cluster
@@ -11,5 +13,7 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: test-bucket-all
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   forProvider: {} 

--- a/e2e/tests/ceph/provider-ceph/07-disable-lifecycle-config.yaml
+++ b/e2e/tests/ceph/provider-ceph/07-disable-lifecycle-config.yaml
@@ -2,6 +2,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: test-bucket
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   providers:
   - ceph-cluster

--- a/e2e/tests/stable/provider-ceph/02-bucket-for-all.yaml
+++ b/e2e/tests/stable/provider-ceph/02-bucket-for-all.yaml
@@ -2,6 +2,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: bucket-for-all-prov-set
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   providers:
   - localstack-a
@@ -22,6 +24,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: bucket-for-all-prov-empty
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   autoPause: true
   forProvider: {}

--- a/e2e/tests/stable/provider-ceph/03-disable-lc-config.yaml
+++ b/e2e/tests/stable/provider-ceph/03-disable-lc-config.yaml
@@ -2,6 +2,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: bucket-for-all-prov-set
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   providers:
   - localstack-a

--- a/e2e/tests/stable/provider-ceph/05-bucket-for-localstack-b.yaml
+++ b/e2e/tests/stable/provider-ceph/05-bucket-for-localstack-b.yaml
@@ -2,6 +2,8 @@ apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
 kind: Bucket
 metadata:
   name: bucket-for-localstack-b
+  labels:
+    provider-ceph.crossplane.io/validation-required: "true"
 spec:
   providers:
   - localstack-b

--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -13,6 +12,9 @@ webhooks:
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
   failurePolicy: Fail
   name: bucket-validation.providerceph.crossplane.io
+  objectSelector:
+    matchLabels:
+      provider-ceph.crossplane.io/validation-required: "true"
   rules:
   - apiGroups:
     - provider-ceph.ceph.crossplane.io

--- a/staging/validatingwebhookconfiguration/kustomization.yaml
+++ b/staging/validatingwebhookconfiguration/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- manifests.yaml
+
+patches:
+- path: patch.yaml
+  target:
+    kind: ValidatingWebhookConfiguration

--- a/staging/validatingwebhookconfiguration/patch.yaml
+++ b/staging/validatingwebhookconfiguration/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: bucket-validation.providerceph.crossplane.io
+  objectSelector:
+    matchLabels:
+      provider-ceph.crossplane.io/validation-required: "true" 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add an `objectlSelector` label to the validating webhook. There is no existing way to do this with kubebuilder tags (at least I cannot find one :upside_down_face:) so it needs a bit of a kustomize workaround.

It puts the responsibility on the user of applying the label to the Bucket CR, which isn't ideal. But we do have some precedence for this with the pause label. On the plus side, it makes opting in/out of validation on a Bucket by Bucket basis possible.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example


-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Minor updates made to kuttl tests with same outcome.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
