### PR TITLE
Add extra check for non-existent lifecycle config

### DIFF
--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -87,7 +87,7 @@ func (l *LifecycleConfigurationClient) observeBackend(ctx context.Context, bucke
 	if bucket.Spec.ForProvider.LifecycleConfiguration == nil || bucket.Spec.LifecycleConfigurationDisabled {
 		// No lifecycle config is specified, or it has been disabled.
 		// Either way, it should not exist on any backend.
-		if LifecycleConfigurationNotFound(err) {
+		if LifecycleConfigurationNotFound(err) || len(response.Rules) == 0 {
 			// No lifecycle config found on this backend.
 			return Updated, nil
 		} else {

--- a/internal/controller/bucket/lifecycleconfiguration_test.go
+++ b/internal/controller/bucket/lifecycleconfiguration_test.go
@@ -111,7 +111,11 @@ func TestObserveBackend(t *testing.T) {
 
 						GetBucketLifecycleConfigurationStub: func(ctx context.Context, lci *s3.GetBucketLifecycleConfigurationInput, f ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error) {
 							return &s3.GetBucketLifecycleConfigurationOutput{
-								Rules: []s3types.LifecycleRule{},
+								Rules: []s3types.LifecycleRule{
+									{
+										Status: "Enabled",
+									},
+								},
 							}, nil
 						},
 					}
@@ -179,7 +183,11 @@ func TestObserveBackend(t *testing.T) {
 
 						GetBucketLifecycleConfigurationStub: func(ctx context.Context, lci *s3.GetBucketLifecycleConfigurationInput, f ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error) {
 							return &s3.GetBucketLifecycleConfigurationOutput{
-								Rules: []s3types.LifecycleRule{},
+								Rules: []s3types.LifecycleRule{
+									{
+										Status: "Enabled",
+									},
+								},
 							}, nil
 						},
 					}

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -135,15 +135,16 @@ func (c *external) updateAll(ctx context.Context, bucket *v1alpha1.Bucket) error
 			continue
 		}
 
-		c.log.Info("Updating bucket", "bucket name", bucket.Name, "backend name", backendName)
-
 		beName := backendName
 		g.Go(func() error {
+			// Set the Bucket status to 'NotReady' until we have successfully performed the update.
 			bucketBackends.setBucketStatus(bucket.Name, beName, v1alpha1.NotReadyStatus)
 
 			for i := 0; i < s3internal.RequestRetries; i++ {
+				c.log.Info("Updating bucket on backend", "bucket_name", bucket.Name, "backend_name", beName)
 				bucketExists, err := s3internal.BucketExists(ctx, cl, bucket.Name)
 				if err != nil {
+					c.log.Info("Error occurred attempting HeadBucket", "err", err.Error(), "bucket_name", bucket.Name, "backend_ name", beName)
 					return err
 				}
 				if !bucketExists {
@@ -152,19 +153,24 @@ func (c *external) updateAll(ctx context.Context, bucket *v1alpha1.Bucket) error
 					return nil
 				}
 
-				bucketBackends.setBucketStatus(bucket.Name, beName, v1alpha1.NotReadyStatus)
-
 				err = c.update(ctx, bucket, beName, bucketBackends)
-				if err == nil {
-					// Check to see if this backend has been marked as 'Unhealthy'. It may be 'Unknown' due to
-					// the healthcheck being disabled. In which case we can only assume the backend is healthy
-					// and mark the bucket as 'Ready' for this backend.
-					if c.backendStore.GetBackendHealthStatus(beName) == apisv1alpha1.HealthStatusUnhealthy {
-						break
-					}
+				if err != nil {
+					c.log.Info("Error occurred attempting to update bucket", "err", err.Error(), "bucket_name", bucket.Name, "backend_ name", beName)
 
-					bucketBackends.setBucketStatus(bucket.Name, beName, v1alpha1.ReadyStatus)
+					continue
 				}
+				// Check if this backend has been marked as 'Unhealthy'. In which case the
+				// Bucket must remain in 'NotReady' state for this backend.
+				if c.backendStore.GetBackendHealthStatus(beName) == apisv1alpha1.HealthStatusUnhealthy {
+
+					return nil
+				}
+				// Bucket has been successfullly updated and the backend is either 'Healthy' or 'Unknown'.
+				// It may be 'Unknown' due to the healthcheck being disabled, in which case we can only assume
+				// the backend is healthy. Either way, set the bucket status as 'Ready' for this backend.
+				bucketBackends.setBucketStatus(bucket.Name, beName, v1alpha1.ReadyStatus)
+
+				return nil
 			}
 
 			return nil

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -145,6 +145,7 @@ func (c *external) updateAll(ctx context.Context, bucket *v1alpha1.Bucket) error
 				bucketExists, err := s3internal.BucketExists(ctx, cl, bucket.Name)
 				if err != nil {
 					c.log.Info("Error occurred attempting HeadBucket", "err", err.Error(), "bucket_name", bucket.Name, "backend_ name", beName)
+
 					return err
 				}
 				if !bucketExists {
@@ -162,10 +163,9 @@ func (c *external) updateAll(ctx context.Context, bucket *v1alpha1.Bucket) error
 				// Check if this backend has been marked as 'Unhealthy'. In which case the
 				// Bucket must remain in 'NotReady' state for this backend.
 				if c.backendStore.GetBackendHealthStatus(beName) == apisv1alpha1.HealthStatusUnhealthy {
-
 					return nil
 				}
-				// Bucket has been successfullly updated and the backend is either 'Healthy' or 'Unknown'.
+				// Bucket has been successfully updated and the backend is either 'Healthy' or 'Unknown'.
 				// It may be 'Unknown' due to the healthcheck being disabled, in which case we can only assume
 				// the backend is healthy. Either way, set the bucket status as 'Ready' for this backend.
 				bucketBackends.setBucketStatus(bucket.Name, beName, v1alpha1.ReadyStatus)

--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -12,9 +13,6 @@ webhooks:
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
   failurePolicy: Fail
   name: bucket-validation.providerceph.crossplane.io
-  objectSelector:
-    matchLabels:
-      provider-ceph.crossplane.io/validation-required: "true"
   rules:
   - apiGroups:
     - provider-ceph.ceph.crossplane.io

--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -13,6 +12,9 @@ webhooks:
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
   failurePolicy: Fail
   name: bucket-validation.providerceph.crossplane.io
+  objectSelector:
+    matchLabels:
+      provider-ceph.crossplane.io/validation-required: "true"
   rules:
   - apiGroups:
     - provider-ceph.ceph.crossplane.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The existing check was fine for localstack. But on Ceph the same check fails because there is no error returned, instead a response containing a lifecycle config with no rules - so we check for this too.

The other edit was a slight bug - Update was unnecessarily looping because we were not exiting correctly.
I restructured this slightly to make it more readable and added a couple of comments/logs.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Passes CI and Ceph Kuttl tests. Also tested locally against latest OBJ
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
