### PR TITLE
Better error handling for lifecycle config

### DIFF
--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -29,14 +29,24 @@ func NewLifecycleConfigurationClient(backendStore *backendstore.BackendStore, lo
 	return &LifecycleConfigurationClient{backendStore: backendStore, log: log}
 }
 
-// LifecycleNotFoundErrCode is the error code sent by AWS when the lifecycle config does not exist
+// LifecycleNotFoundErrCode is the error code sent by Ceph when the lifecycle config does not exist
 var LifecycleNotFoundErrCode = "NoSuchLifecycleConfiguration"
 
-// LifecycleConfigurationNotFound is parses the aws Error and validates if the lifecycle configuration does not exist
+// LifecycleConfigurationNotFound is parses the error and validates if the lifecycle configuration does not exist
 func LifecycleConfigurationNotFound(err error) bool {
 	var awsErr smithy.APIError
 
 	return errors.As(err, &awsErr) && awsErr.ErrorCode() == LifecycleNotFoundErrCode
+}
+
+// NoSuchBucketErrCode is the error code sent by Ceph when the bucket does not exist
+var NoSuchBucketErrCode = "NoSuchBucket"
+
+// BucketNotFound parses the error and validates if the bucket does not exist
+func BucketNotFound(err error) bool {
+	var awsErr smithy.APIError
+
+	return errors.As(err, &awsErr) && awsErr.ErrorCode() == NoSuchBucketErrCode
 }
 
 func (l *LifecycleConfigurationClient) Observe(ctx context.Context, bucket *v1alpha1.Bucket, backendNames []string) (ResourceStatus, error) {
@@ -80,18 +90,20 @@ func (l *LifecycleConfigurationClient) observeBackend(ctx context.Context, bucke
 	s3Client := l.backendStore.GetBackendClient(backendName)
 
 	response, err := s3Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket.Name)})
-	if resource.Ignore(LifecycleConfigurationNotFound, err) != nil {
+	if resource.IgnoreAny(err, LifecycleConfigurationNotFound, BucketNotFound) != nil {
 		return NeedsUpdate, errors.Wrap(err, errGetLifecycleConfig)
 	}
 
 	if bucket.Spec.ForProvider.LifecycleConfiguration == nil || bucket.Spec.LifecycleConfigurationDisabled {
 		// No lifecycle config is specified, or it has been disabled.
 		// Either way, it should not exist on any backend.
-		if LifecycleConfigurationNotFound(err) || len(response.Rules) == 0 {
+		if response == nil || len(response.Rules) == 0 {
 			// No lifecycle config found on this backend.
+			l.log.Info("no lifecycle configuration found on backend - no action required", "bucket_name", bucket.Name, "backend_name", backendName)
+
 			return Updated, nil
 		} else {
-			l.log.Info("lifecycle found on backend - requires deletion", "bucket_name", bucket.Name)
+			l.log.Info("lifecycle configuration found on backend - requires deletion", "bucket_name", bucket.Name, "backend_name", backendName)
 
 			return NeedsDeletion, nil
 		}

--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -43,7 +43,7 @@ func LifecycleConfigurationNotFound(err error) bool {
 var NoSuchBucketErrCode = "NoSuchBucket"
 
 // BucketNotFound parses the error and validates if the bucket does not exist
-func BucketNotFound(err error) bool {
+func IsBucketNotFound(err error) bool {
 	var awsErr smithy.APIError
 
 	return errors.As(err, &awsErr) && awsErr.ErrorCode() == NoSuchBucketErrCode

--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -90,7 +90,7 @@ func (l *LifecycleConfigurationClient) observeBackend(ctx context.Context, bucke
 	s3Client := l.backendStore.GetBackendClient(backendName)
 
 	response, err := s3Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket.Name)})
-	if resource.IgnoreAny(err, LifecycleConfigurationNotFound, BucketNotFound) != nil {
+	if resource.IgnoreAny(err, LifecycleConfigurationNotFound, IsBucketNotFound) != nil {
 		return NeedsUpdate, errors.Wrap(err, errGetLifecycleConfig)
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
I thought that #97 had fixed this issue but I had gotten a false positive when testing :upside_down_face: 

We were only checking for `NoSuchLifecycleConfiguration` in the returned errors from `GetBucketLifecycleConfiguration`. However if the bucket itself does not exist then the error will be `NoSuchBucket`, in which case we have nothing to do for the sub-resource (lifecycle configuration). 

This situation can arise easily when a bucket is deleted via the `Disabled` flag. As it invokes an Update call which means a bucket can be deleted off the backend before `observeBackend` is called to check for any updates required to lifecycle configs.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
