### PR TITLE
Remove deprecated health check bucket

### DIFF
--- a/apis/provider-ceph/v1alpha1/utils.go
+++ b/apis/provider-ceph/v1alpha1/utils.go
@@ -17,19 +17,5 @@ limitations under the License.
 package v1alpha1
 
 const (
-	HealthCheckLabelKey = "provider-ceph.crossplane.io"
-	HealthCheckLabelVal = "health-check-bucket"
-	BackendLabelPrefix  = "provider-ceph.backends."
+	BackendLabelPrefix = "provider-ceph.backends."
 )
-
-// Deprecation warning: This function exists for compatibility reasons,
-// and would be removed soon.
-func IsHealthCheckBucket(bucket *Bucket) bool {
-	if val, ok := bucket.GetLabels()[HealthCheckLabelKey]; ok {
-		if val == HealthCheckLabelVal {
-			return true
-		}
-	}
-
-	return false
-}

--- a/internal/controller/bucket/bucket_test.go
+++ b/internal/controller/bucket/bucket_test.go
@@ -483,64 +483,6 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"Bucket check on external - OK, Health check bucket ignores auto pause": {
-			fields: fields{
-				backendStore: func() *backendstore.BackendStore {
-					fake := backendstorefakes.FakeS3Client{
-						HeadBucketStub: func(ctx context.Context, hbi *s3.HeadBucketInput, f ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
-							return &s3.HeadBucketOutput{}, nil
-						},
-					}
-
-					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-1", &fake, true, apisv1alpha1.HealthStatusHealthy)
-
-					return bs
-				}(),
-				autoPauseBucket: true,
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Finalizers: []string{inUseFinalizer},
-						Labels: map[string]string{
-							v1alpha1.HealthCheckLabelKey: v1alpha1.HealthCheckLabelVal,
-						},
-					},
-					Spec: v1alpha1.BucketSpec{
-						Providers: []string{"s3-backend-1"},
-						ResourceSpec: v1.ResourceSpec{
-							ProviderConfigReference: &v1.Reference{
-								Name: "s3-backend-1",
-							},
-						},
-					},
-					Status: v1alpha1.BucketStatus{
-						AtProvider: v1alpha1.BucketObservation{
-							Backends: v1alpha1.Backends{
-								"s3-backend-1": &v1alpha1.BackendInfo{
-									BucketStatus: v1alpha1.ReadyStatus,
-								},
-							},
-						},
-						ResourceStatus: v1.ResourceStatus{
-							ConditionedStatus: v1.ConditionedStatus{
-								Conditions: []v1.Condition{
-									v1.Available(),
-								},
-							},
-						},
-					},
-				},
-			},
-			want: want{
-				o: managed.ExternalObservation{
-					ResourceExists:    true,
-					ResourceUpToDate:  true,
-					ConnectionDetails: managed.ConnectionDetails{},
-				},
-			},
-		},
 	}
 	for name, tc := range cases {
 		tc := tc
@@ -819,23 +761,6 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				err: errors.New(errNotBucket),
-			},
-		},
-		"OK - Health check bucket": {
-			fields: fields{
-				backendStore: backendstore.NewBackendStore(),
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							v1alpha1.HealthCheckLabelKey: v1alpha1.HealthCheckLabelVal,
-						},
-					},
-				},
-			},
-			want: want{
-				o: managed.ExternalUpdate{},
 			},
 		},
 		"Bucket is disabled": {

--- a/internal/controller/bucket/bucket_validation_webhook.go
+++ b/internal/controller/bucket/bucket_validation_webhook.go
@@ -73,14 +73,6 @@ func (b *BucketValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 }
 
 func (b *BucketValidator) validateCreateOrUpdate(ctx context.Context, bucket *v1alpha1.Bucket) error {
-	// Ignore validation for health check buckets as they do not
-	// behave as 'normal' buckets. For example, health check buckets
-	// need to be updated after their owning ProviderConfig has been deleted.
-	// This is to remove a finalizer and enable garbage collection.
-	if v1alpha1.IsHealthCheckBucket(bucket) {
-		return nil
-	}
-
 	if len(bucket.Spec.Providers) != 0 {
 		missingProviders := utils.MissingStrings(bucket.Spec.Providers, b.backendStore.GetAllActiveBackendNames())
 		if len(missingProviders) != 0 {

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -72,12 +72,6 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 			return managed.ExternalCreation{}, errors.Wrap(err, errGetPC)
 		}
 
-		if v1alpha1.IsHealthCheckBucket(bucket) && pc.Spec.DisableHealthCheck {
-			c.log.Info("Health check is disabled on backend - health-check-bucket will not be created", "backend name", beName)
-
-			continue
-		}
-
 		errorsLeft++
 
 		beName := beName

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -24,12 +24,6 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	ctx, cancel := context.WithTimeout(ctx, c.operationTimeout)
 	defer cancel()
 
-	if v1alpha1.IsHealthCheckBucket(bucket) {
-		c.log.Info("Delete is NOOP for health check bucket as it is owned by, and garbage collected on deletion of its related providerconfig", "bucket", bucket.Name)
-
-		return nil
-	}
-
 	// There are two scenarios where the bucket status needs to be updated during a
 	// Delete invocation:
 	// 1. The caller attempts to delete the CR and an error occurs during the call to

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -36,7 +36,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		}, nil
 	}
 
-	if !v1alpha1.IsHealthCheckBucket(bucket) && (bucket.Spec.AutoPause || c.autoPauseBucket) && bucket.Labels[meta.AnnotationKeyReconciliationPaused] == "" {
+	if (bucket.Spec.AutoPause || c.autoPauseBucket) && bucket.Labels[meta.AnnotationKeyReconciliationPaused] == "" {
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,
@@ -58,7 +58,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			break
 		}
 	}
-	if !available && !v1alpha1.IsHealthCheckBucket(bucket) {
+	if !available {
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -27,12 +27,6 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errNotBucket)
 	}
 
-	if v1alpha1.IsHealthCheckBucket(bucket) {
-		c.log.Info("Update is NOOP for health check bucket - updates performed by health-check-controller", "bucket", bucket.Name)
-
-		return managed.ExternalUpdate{}, nil
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, c.operationTimeout)
 	defer cancel()
 
@@ -74,8 +68,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 				}
 			}
 
-			if !v1alpha1.IsHealthCheckBucket(bucket) &&
-				allBucketsReady &&
+			if allBucketsReady &&
 				(bucket.Spec.AutoPause || c.autoPauseBucket) &&
 				bucket.Labels[meta.AnnotationKeyReconciliationPaused] != "true" {
 				c.log.Info("Auto pausing bucket", "bucket_name", bucket.Name)

--- a/internal/controller/providerconfig/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck_controller.go
@@ -322,8 +322,7 @@ func (r *HealthCheckReconciler) unpauseBuckets(ctx context.Context, s3BackendNam
 			Factor:   factor,
 			Jitter:   jitter,
 		}, resource.IsAPIError, func() error {
-			if !v1alpha1.IsHealthCheckBucket(&buckets.Items[i]) &&
-				(r.autoPauseBucket || buckets.Items[i].Spec.AutoPause) &&
+			if (r.autoPauseBucket || buckets.Items[i].Spec.AutoPause) &&
 				buckets.Items[i].Labels[meta.AnnotationKeyReconciliationPaused] == "true" {
 				buckets.Items[i].Labels[meta.AnnotationKeyReconciliationPaused] = ""
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The idea of a "Health Check Bucket" has been removed now for a while. 
The health check bucket still exists, but it is not represented by a bucket CR with a specific label, as was the case originally.
So this PR just removes all previous references to that type of "special" bucket - no change to existing logic.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI - there is no functional change
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
