### PR TITLE
Better error handling and default retry settings

### DIFF
--- a/internal/controller/bucket/create_test.go
+++ b/internal/controller/bucket/create_test.go
@@ -146,6 +146,8 @@ func TestCreateBasicErrors(t *testing.T) {
 
 //nolint:paralleltest // Running in parallel causes issues with client.
 func TestCreate(t *testing.T) {
+	randomErr := errors.New("some error")
+
 	type fields struct {
 		backendStore    *backendstore.BackendStore
 		providerConfigs *apisv1alpha1.ProviderConfigList
@@ -241,7 +243,7 @@ func TestCreate(t *testing.T) {
 
 					fakeClientError.CreateBucketReturns(
 						&s3.CreateBucketOutput{},
-						errors.New("some error"),
+						randomErr,
 					)
 
 					fakeClientOK.CreateBucketReturns(
@@ -306,7 +308,7 @@ func TestCreate(t *testing.T) {
 
 					fakeClientError.CreateBucketReturns(
 						&s3.CreateBucketOutput{},
-						errors.New("some error"),
+						randomErr,
 					)
 
 					bs := backendstore.NewBackendStore()
@@ -325,7 +327,7 @@ func TestCreate(t *testing.T) {
 				},
 			},
 			want: want{
-				err: nil,
+				err: randomErr,
 				statusDiff: func(t *testing.T, mg resource.Managed) {
 					t.Helper()
 					bucket, _ := mg.(*v1alpha1.Bucket)

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -93,8 +93,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 		return NeedsStatusUpdate
 	}); err != nil {
-		c.log.Info("Failed to update Bucket Status after attempting to delete bucket from backends", consts.KeyBucketName, bucket.Name)
-		err := errors.Wrap(err, errUpdateBucketCR)
+		err = errors.Wrap(err, errUpdateBucketCR)
+		c.log.Info("Failed to update Bucket Status after attempting to delete bucket from backends", consts.KeyBucketName, bucket.Name, "error", err.Error())
 		traces.SetAndRecordError(span, err)
 
 		return err
@@ -119,8 +119,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 		return NeedsObjectUpdate
 	}); err != nil {
-		c.log.Info("Failed to remove 'in-use' finalizer from Bucket CR", consts.KeyBucketName, bucket.Name)
-		err := errors.Wrap(err, errUpdateBucketCR)
+		err = errors.Wrap(err, errUpdateBucketCR)
+		c.log.Info("Failed to remove 'in-use' finalizer from Bucket CR", consts.KeyBucketName, bucket.Name, "error", err.Error())
 		traces.SetAndRecordError(span, err)
 
 		return err

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -96,6 +96,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 		c.log.Info("Failed to update Bucket Status after attempting to delete bucket from backends", consts.KeyBucketName, bucket.Name)
 		err := errors.Wrap(err, errUpdateBucketCR)
 		traces.SetAndRecordError(span, err)
+
+		return err
 	}
 
 	// If an error occurred during deletion, we must return for requeue.

--- a/internal/controller/bucket/delete_test.go
+++ b/internal/controller/bucket/delete_test.go
@@ -315,6 +315,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket",
 						Finalizers: []string{v1alpha1.InUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{
@@ -384,6 +385,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket",
 						Finalizers: []string{v1alpha1.InUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{
@@ -459,6 +461,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket",
 						Finalizers: []string{v1alpha1.InUseFinalizer},
 					},
 					Spec: v1alpha1.BucketSpec{

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -13,7 +13,6 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -168,20 +167,8 @@ func (c *external) updateBucketCR(ctx context.Context, bucket *v1alpha1.Bucket, 
 
 	nn := types.NamespacedName{Name: bucket.GetName()}
 
-	const (
-		steps  = 3
-		divide = 2
-		factor = 0.5
-		jitter = 0.1
-	)
-
 	for _, cb := range callbacks {
-		err := retry.OnError(wait.Backoff{
-			Steps:    steps,
-			Duration: c.operationTimeout / divide,
-			Factor:   factor,
-			Jitter:   jitter,
-		}, resource.IsAPIError, func() error {
+		err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
 			if err := c.kubeClient.Get(ctx, nn, bucket); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The custom backoff retry settings occasionally leave us in a situation where we fail to remove the in-use finalizer after a successful delete and the request is not re-queued. Using the recommended retry backoff solves this issue.

Other changes are better error handling and logging errors where necessary 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
