### PR TITLE
Update .golangci.yml with timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 2m
+  timrout: 2m
 
   skip-files:
   - "zz_generated\\..+\\.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timrout: 2m
+  timeout: 3m
 
   skip-files:
   - "zz_generated\\..+\\.go$"


### PR DESCRIPTION
Deadline has been deprecated.