### PR TITLE
Use event filter to fix exponential backoff

### DIFF
--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -81,7 +81,6 @@ func (l *LifecycleConfigurationClient) Observe(ctx context.Context, bucket *v1al
 func (l *LifecycleConfigurationClient) observeBackend(ctx context.Context, bucket *v1alpha1.Bucket, backendName string) (ResourceStatus, error) {
 	l.log.Info("Observing subresource lifecycle configuration on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
 
-	s3Client := l.backendStore.GetBackendClient(backendName)
 	if l.backendStore.GetBackendHealthStatus(backendName) == apisv1alpha1.HealthStatusUnhealthy {
 		// If a backend is marked as unhealthy, we can ignore it for now by returning Updated.
 		// The backend may be down for some time and we do not want to block Create/Update/Delete
@@ -90,6 +89,7 @@ func (l *LifecycleConfigurationClient) observeBackend(ctx context.Context, bucke
 		return Updated, nil
 	}
 
+	s3Client := l.backendStore.GetBackendClient(backendName)
 	response, err := s3internal.GetBucketLifecycleConfiguration(ctx, s3Client, aws.String(bucket.Name))
 	if err != nil {
 		return NeedsUpdate, err

--- a/internal/controller/bucket/lifecycleconfiguration_test.go
+++ b/internal/controller/bucket/lifecycleconfiguration_test.go
@@ -99,6 +99,30 @@ func TestObserveBackend(t *testing.T) {
 				err:    errExternal,
 			},
 		},
+		"Attempt to observe lifecycle config on unhealthy backend (consider it updated to unblock)": {
+			fields: fields{
+				backendStore: func() *backendstore.BackendStore {
+					fake := backendstorefakes.FakeS3Client{}
+
+					bs := backendstore.NewBackendStore()
+					bs.AddOrUpdateBackend("s3-backend-1", &fake, true, apisv1alpha1.HealthStatusUnhealthy)
+
+					return bs
+				}(),
+			},
+			args: args{
+				bucket: &v1alpha1.Bucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bucket",
+					},
+				},
+				backendName: "s3-backend-1",
+			},
+			want: want{
+				status: Updated,
+				err:    nil,
+			},
+		},
 		"Lifecycle config not specified in CR but exists on backend so NeedsDeletion": {
 			fields: fields{
 				backendStore: func() *backendstore.BackendStore {

--- a/internal/controller/bucket/setup.go
+++ b/internal/controller/bucket/setup.go
@@ -69,6 +69,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, c *Connector) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
 		For(&v1alpha1.Bucket{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add Event Filter to the bucket controller - without this small change, the exponential backoff is not being enforced.
See https://github.com/crossplane/crossplane/issues/3840 and fix https://github.com/crossplane/crossplane-runtime/pull/417 for more context.

Also, while testing this out by intentionally disabling a backend to cause a `Delete` error, I noticed that the lifecycle config `Observe` was blocking subsequent operations `Create`/`Update`/`Delete` if a backend cannot be reached. In this event, we should unblock and allow the subsequent calls to take place for the remaining backends.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually plus existing CI - also added a unit test case
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
