### PR TITLE
Remove manual retry loops and add --s3-timeout flag

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -83,6 +83,7 @@ func main() {
 		reconcileConcurrency = app.Flag("reconcile-concurrency", "Set number of reconciliation loops.").Default("100").Int()
 		maxReconcileRate     = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("1000").Int()
 		reconcileTimeout     = app.Flag("reconcile-timeout", "Object reconciliation timeout").Short('t').Default("3s").Duration()
+		s3Timeout            = app.Flag("s3-timeout", "S3 API operations timeout").Default("10s").Duration()
 		creationGracePeriod  = app.Flag("creation-grace-period", "Duration to wait for the external API to report that a newly created external resource exists.").Default("10s").Duration()
 		tracesEnabled        = app.Flag("otel-enable-tracing", "").Default("false").Bool()
 		tracesExportTimeout  = app.Flag("otel-traces-export-timeout", "Timeout when exporting traces").Default("2s").Duration()
@@ -274,6 +275,7 @@ func main() {
 		backendmonitor.NewController(
 			backendmonitor.WithKubeClient(mgr.GetClient()),
 			backendmonitor.WithBackendStore(backendStore),
+			backendmonitor.WithS3Timeout(*s3Timeout),
 			backendmonitor.WithLogger(o.Logger)),
 		healthcheck.NewController(
 			healthcheck.WithAutoPause(autoPauseBucket),

--- a/internal/controller/bucket/bucket_validation_webhook.go
+++ b/internal/controller/bucket/bucket_validation_webhook.go
@@ -100,25 +100,14 @@ func (b *BucketValidator) validateLifecycleConfiguration(ctx context.Context, bu
 
 	// Create dummy bucket 'life-cycle-configuration-validation-bucket' for the lifecycle config validation.
 	// Cleanup of this bucket is performed by the health-check controller on deletion of the ProviderConfig.
-	var err error
-	for i := 0; i < s3internal.RequestRetries; i++ {
-		_, err = s3internal.CreateBucket(ctx, s3Client, s3internal.BucketToCreateBucketInput(dummyBucket))
-		if err == nil {
-			break
-		}
-	}
+	_, err := s3internal.CreateBucket(ctx, s3Client, s3internal.BucketToCreateBucketInput(dummyBucket))
 	if err != nil {
 		return err
 	}
 
 	// Attempt to Put the lifecycle config.
 	dummyBucket.Spec.ForProvider.LifecycleConfiguration = bucket.Spec.ForProvider.LifecycleConfiguration
-	for i := 0; i < s3internal.RequestRetries; i++ {
-		_, err = s3internal.PutBucketLifecycleConfiguration(ctx, s3Client, dummyBucket)
-		if err == nil {
-			break
-		}
-	}
+	_, err = s3internal.PutBucketLifecycleConfiguration(ctx, s3Client, dummyBucket)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -100,16 +100,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 		beName := beName
 		go func() {
-			var err error
-
-			for i := 0; i < s3internal.RequestRetries; i++ {
-				_, err = s3internal.CreateBucket(ctx, cl, s3internal.BucketToCreateBucketInput(originalBucket))
-				if err == nil {
-					c.log.Info("Bucket created on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)
-
-					break
-				}
-			}
+			_, err := s3internal.CreateBucket(ctx, cl, s3internal.BucketToCreateBucketInput(originalBucket))
 			if err != nil {
 				c.log.Info("Failed to create bucket on backend", consts.KeyBucketName, originalBucket.Name, consts.KeyBackendName, beName, "err", err.Error())
 				traces.SetAndRecordError(span, err)
@@ -117,7 +108,9 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 				errChan <- err
 
 				return
+
 			}
+			c.log.Info("Bucket created on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)
 
 			// This compare-and-swap operation is the atomic equivalent of:
 			//	if *bucketAlreadyCreated == false {

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -108,7 +108,6 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 				errChan <- err
 
 				return
-
 			}
 			c.log.Info("Bucket created on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)
 

--- a/internal/controller/providerconfig/backendmonitor/backendmonitor.go
+++ b/internal/controller/providerconfig/backendmonitor/backendmonitor.go
@@ -1,6 +1,8 @@
 package backendmonitor
 
 import (
+	"time"
+
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
@@ -13,6 +15,7 @@ type Controller struct {
 	kubeClient   client.Client
 	backendStore *backendstore.BackendStore
 	log          logging.Logger
+	s3Timeout    time.Duration
 }
 
 func NewController(options ...func(*Controller)) *Controller {
@@ -39,6 +42,12 @@ func WithLogger(l logging.Logger) func(*Controller) {
 func WithBackendStore(b *backendstore.BackendStore) func(*Controller) {
 	return func(r *Controller) {
 		r.backendStore = b
+	}
+}
+
+func WithS3Timeout(t time.Duration) func(*Controller) {
+	return func(r *Controller) {
+		r.s3Timeout = t
 	}
 }
 

--- a/internal/controller/providerconfig/backendmonitor/backendmonitor_controller.go
+++ b/internal/controller/providerconfig/backendmonitor/backendmonitor_controller.go
@@ -76,7 +76,7 @@ func (c *Controller) addOrUpdateBackend(ctx context.Context, pc *apisv1alpha1.Pr
 		return err
 	}
 
-	s3client, err := s3internal.NewClient(ctx, secret.Data, &pc.Spec)
+	s3client, err := s3internal.NewClient(ctx, secret.Data, &pc.Spec, c.s3Timeout)
 	if err != nil {
 		return errors.Wrap(err, errCreateClient)
 	}

--- a/internal/s3/bucket.go
+++ b/internal/s3/bucket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -24,8 +23,7 @@ const (
 	errHeadBucket   = "failed to perform head bucket"
 )
 
-func CreateBucket(ctx context.Context, s3Backend backendstore.S3Client, bucket *awss3.CreateBucketInput, o ...func(*s3.Options)) (*awss3.CreateBucketOutput, error) {
-
+func CreateBucket(ctx context.Context, s3Backend backendstore.S3Client, bucket *awss3.CreateBucketInput, o ...func(*awss3.Options)) (*awss3.CreateBucketOutput, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "CreateBucket")
 	defer span.End()
 
@@ -41,7 +39,7 @@ func CreateBucket(ctx context.Context, s3Backend backendstore.S3Client, bucket *
 	return resp, err
 }
 
-func BucketExists(ctx context.Context, s3Backend backendstore.S3Client, bucketName string, o ...func(*s3.Options)) (bool, error) {
+func BucketExists(ctx context.Context, s3Backend backendstore.S3Client, bucketName string, o ...func(*awss3.Options)) (bool, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "BucketExists")
 	defer span.End()
 
@@ -63,7 +61,7 @@ func BucketExists(ctx context.Context, s3Backend backendstore.S3Client, bucketNa
 	return true, nil
 }
 
-func DeleteBucket(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*s3.Options)) error {
+func DeleteBucket(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*awss3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "DeleteBucket")
 	defer span.End()
 
@@ -106,7 +104,7 @@ func DeleteBucket(ctx context.Context, s3Backend backendstore.S3Client, bucketNa
 	return nil
 }
 
-func deleteBucketObjects(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*s3.Options)) error {
+func deleteBucketObjects(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*awss3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "deleteBucketObjects")
 	defer span.End()
 
@@ -149,7 +147,7 @@ func deleteBucketObjects(ctx context.Context, s3Backend backendstore.S3Client, b
 	return nil
 }
 
-func deleteBucketObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*s3.Options)) error {
+func deleteBucketObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, bucketName *string, o ...func(*awss3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "deleteBucketObjectVersions")
 	defer span.End()
 

--- a/internal/s3/bucket.go
+++ b/internal/s3/bucket.go
@@ -21,8 +21,6 @@ const (
 	errUpdateBucket = "failed to update bucket"
 	errDeleteBucket = "failed to delete bucket"
 	errHeadBucket   = "failed to perform head bucket"
-
-	RequestRetries = 5
 )
 
 func CreateBucket(ctx context.Context, s3Backend backendstore.S3Client, bucket *awss3.CreateBucketInput) (*awss3.CreateBucketOutput, error) {

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -48,7 +48,6 @@ func NewClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1
 	return s3.NewFromConfig(sessionConfig, func(o *s3.Options) {
 		o.UsePathStyle = true
 		o.HTTPClient = &http.Client{Timeout: s3Timeout}
-
 	}), nil
 }
 

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -2,7 +2,9 @@ package s3
 
 import (
 	"context"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -20,7 +22,7 @@ const (
 	secretKey = "secret_key"
 )
 
-func NewClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec) (*s3.Client, error) {
+func NewClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration) (*s3.Client, error) {
 	hostBase := resolveHostBase(pcSpec.HostBase, pcSpec.UseHTTPS)
 
 	endpointResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
@@ -45,6 +47,8 @@ func NewClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1
 
 	return s3.NewFromConfig(sessionConfig, func(o *s3.Options) {
 		o.UsePathStyle = true
+		o.HTTPClient = &http.Client{Timeout: s3Timeout}
+
 	}), nil
 }
 

--- a/internal/s3/object.go
+++ b/internal/s3/object.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/linode/provider-ceph/internal/backendstore"
@@ -18,11 +19,11 @@ const (
 	errPutObject          = "failed to put object"
 )
 
-func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.GetObjectInput) (*awss3.GetObjectOutput, error) {
+func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.GetObjectInput, o ...func(*s3.Options)) (*awss3.GetObjectOutput, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "GetObject")
 	defer span.End()
 
-	resp, err := s3Backend.GetObject(ctx, input)
+	resp, err := s3Backend.GetObject(ctx, input, o...)
 	if err != nil {
 		err = errors.Wrap(err, errGetObject)
 		traces.SetAndRecordError(span, err)
@@ -33,11 +34,11 @@ func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss
 	return resp, nil
 }
 
-func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.DeleteObjectInput) error {
+func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.DeleteObjectInput, o ...func(*s3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "DeleteObject")
 	defer span.End()
 
-	_, err := s3Backend.DeleteObject(ctx, input)
+	_, err := s3Backend.DeleteObject(ctx, input, o...)
 	if err != nil {
 		err = errors.Wrap(err, errDeleteObject)
 		traces.SetAndRecordError(span, err)
@@ -48,11 +49,11 @@ func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *a
 	return nil
 }
 
-func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.PutObjectInput) error {
+func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.PutObjectInput, o ...func(*s3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "PutObject")
 	defer span.End()
 
-	_, err := s3Backend.PutObject(ctx, input)
+	_, err := s3Backend.PutObject(ctx, input, o...)
 	if err != nil {
 		err = errors.Wrap(err, errPutObject)
 		traces.SetAndRecordError(span, err)
@@ -63,11 +64,11 @@ func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss
 	return nil
 }
 
-func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectsV2Input) (*awss3.ListObjectsV2Output, error) {
+func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectsV2Input, o ...func(*s3.Options)) (*awss3.ListObjectsV2Output, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ListObjectsV2")
 	defer span.End()
 
-	resp, err := s3Backend.ListObjectsV2(ctx, input)
+	resp, err := s3Backend.ListObjectsV2(ctx, input, o...)
 	if err != nil {
 		err = errors.Wrap(err, errListObjects)
 		traces.SetAndRecordError(span, err)
@@ -78,11 +79,11 @@ func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *
 	return resp, nil
 }
 
-func ListObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectVersionsInput) (*awss3.ListObjectVersionsOutput, error) {
+func ListObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectVersionsInput, o ...func(*s3.Options)) (*awss3.ListObjectVersionsOutput, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ListObjectsVersions")
 	defer span.End()
 
-	resp, err := s3Backend.ListObjectVersions(ctx, input)
+	resp, err := s3Backend.ListObjectVersions(ctx, input, o...)
 	if err != nil {
 		err = errors.Wrap(err, errListObjectVersions)
 		traces.SetAndRecordError(span, err)

--- a/internal/s3/object.go
+++ b/internal/s3/object.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/linode/provider-ceph/internal/backendstore"
@@ -19,7 +18,7 @@ const (
 	errPutObject          = "failed to put object"
 )
 
-func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.GetObjectInput, o ...func(*s3.Options)) (*awss3.GetObjectOutput, error) {
+func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.GetObjectInput, o ...func(*awss3.Options)) (*awss3.GetObjectOutput, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "GetObject")
 	defer span.End()
 
@@ -34,7 +33,7 @@ func GetObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss
 	return resp, nil
 }
 
-func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.DeleteObjectInput, o ...func(*s3.Options)) error {
+func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.DeleteObjectInput, o ...func(*awss3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "DeleteObject")
 	defer span.End()
 
@@ -49,7 +48,7 @@ func DeleteObject(ctx context.Context, s3Backend backendstore.S3Client, input *a
 	return nil
 }
 
-func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.PutObjectInput, o ...func(*s3.Options)) error {
+func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.PutObjectInput, o ...func(*awss3.Options)) error {
 	ctx, span := otel.Tracer("").Start(ctx, "PutObject")
 	defer span.End()
 
@@ -64,7 +63,7 @@ func PutObject(ctx context.Context, s3Backend backendstore.S3Client, input *awss
 	return nil
 }
 
-func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectsV2Input, o ...func(*s3.Options)) (*awss3.ListObjectsV2Output, error) {
+func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectsV2Input, o ...func(*awss3.Options)) (*awss3.ListObjectsV2Output, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ListObjectsV2")
 	defer span.End()
 
@@ -79,7 +78,7 @@ func ListObjectsV2(ctx context.Context, s3Backend backendstore.S3Client, input *
 	return resp, nil
 }
 
-func ListObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectVersionsInput, o ...func(*s3.Options)) (*awss3.ListObjectVersionsOutput, error) {
+func ListObjectVersions(ctx context.Context, s3Backend backendstore.S3Client, input *awss3.ListObjectVersionsInput, o ...func(*awss3.Options)) (*awss3.ListObjectVersionsOutput, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ListObjectsVersions")
 	defer span.End()
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- AWS Go SDK already has a built-in `Retryer` for S3 operations, so removing our own loop mechanism as it is unnecessary.
- Make S3 client timeout configurable with `--s3-timeout` (default to 10s).
- Setting a NoOp `Retryer` for the health check operations which has 0 retries - Retries can cause a considerable lag when a backend goes offline. For instance, if a backend becomes unreachable the health check's `HeadBucket` operation will likely only fail when it times out. Therefore, if we are retrying 5 times and each operation has a 10s timeout, we will be waiting 50s for an updated health check status.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually and CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
