### PR TITLE
Add check for LCs before pause

### DIFF
--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -93,7 +93,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 			// Auto pause the Bucket CR if required.
 			cls := c.backendStore.GetBackendClients(bucketLatest.Spec.Providers)
-			if isPauseRequired(bucketLatest, bucketBackends.isBucketAvailableOnBackends(bucketLatest, cls), c.autoPauseBucket) {
+			if isPauseRequired(bucketLatest, cls, bucketBackends, c.autoPauseBucket) {
 				c.log.Info("Auto pausing bucket", consts.KeyBucketName, bucket.Name)
 				pauseBucket(bucketLatest)
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
We should be checking to ensure that lifecycle configs are up to date before pausing the bucket.
Two scenarios we should **not** pause:
- LC Config is enabled and specified in Spec, but is not available on backends - don't pause as we need to reconcile until all are available.
- LC Config is disabled but still exists on backends - don't pause as we need to reconcile until all LC Configs are removed.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually & CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
