### PR TITLE
Add logic for STS client and low-level AssumeRole func

### DIFF
--- a/internal/rgw/assumerole.go
+++ b/internal/rgw/assumerole.go
@@ -1,0 +1,30 @@
+package rgw
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/linode/provider-ceph/internal/backendstore"
+	"github.com/linode/provider-ceph/internal/otel/traces"
+	"go.opentelemetry.io/otel"
+)
+
+const (
+	errAssumeRole = "failed to assume role"
+)
+
+func AssumeRole(ctx context.Context, stsClient backendstore.STSClient, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	ctx, span := otel.Tracer("").Start(ctx, "AssumeRole")
+	defer span.End()
+
+	resp, err := stsClient.AssumeRole(ctx, input)
+	if err != nil {
+		err = errors.Wrap(err, errAssumeRole)
+		traces.SetAndRecordError(span, err)
+
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/internal/rgw/client.go
+++ b/internal/rgw/client.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 )
 
@@ -22,33 +24,56 @@ const (
 	secretKey = "secret_key"
 )
 
-func NewClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration) (*s3.Client, error) {
-	hostBase := resolveHostBase(pcSpec.HostBase, pcSpec.UseHTTPS)
-
-	endpointResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		return aws.Endpoint{
-			URL: hostBase,
-		}, nil
-	})
-
-	sessionConfig, err := config.LoadDefaultConfig(ctx,
-		config.WithEndpointResolverWithOptions(endpointResolver),
-		config.WithRetryMaxAttempts(retry.DefaultRetry.Steps),
-		config.WithRetryMode(aws.RetryModeStandard))
+func NewS3Client(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration) (*s3.Client, error) {
+	sessionConfig, err := buildSessionConfig(ctx, data, pcSpec.HostBase, pcSpec.UseHTTPS)
 	if err != nil {
 		return nil, err
 	}
-
-	// By default make sure a region is specified, this is required for S3 operations
-	region := defaultRegion
-	sessionConfig.Region = aws.ToString(&region)
-
-	sessionConfig.Credentials = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(string(data[accessKey]), string(data[secretKey]), ""))
 
 	return s3.NewFromConfig(sessionConfig, func(o *s3.Options) {
 		o.UsePathStyle = true
 		o.HTTPClient = &http.Client{Timeout: s3Timeout}
 	}), nil
+}
+
+func NewSTSClient(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration) (*sts.Client, error) {
+	// If an STSAddress has not been set in the ProviderConfig Spec, use the HostBase.
+	// The STSAddress is only necessary if we wish to contact an STS compliant authentication
+	// service separate to the HostBase (i.e RGW address).
+	stsAddress := pcSpec.STSAddress
+	if stsAddress == nil {
+		stsAddress = &pcSpec.HostBase
+	}
+
+	sessionConfig, err := buildSessionConfig(ctx, data, *stsAddress, pcSpec.UseHTTPS)
+	if err != nil {
+		return nil, err
+	}
+
+	return sts.NewFromConfig(sessionConfig, func(o *sts.Options) {
+		o.HTTPClient = &http.Client{Timeout: s3Timeout}
+	}), nil
+}
+
+func buildSessionConfig(ctx context.Context, data map[string][]byte, address string, useHTTPS bool) (aws.Config, error) {
+	resolvedAddress := resolveHostBase(address, useHTTPS)
+
+	endpointResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		return aws.Endpoint{
+			URL: resolvedAddress,
+		}, nil
+	})
+
+	return config.LoadDefaultConfig(ctx,
+		config.WithEndpointResolverWithOptions(endpointResolver),
+		config.WithRetryMaxAttempts(retry.DefaultRetry.Steps),
+		config.WithRetryMode(aws.RetryModeStandard),
+		config.WithRegion(defaultRegion),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			string(data[accessKey]),
+			string(data[secretKey]),
+			"",
+		)))
 }
 
 func resolveHostBase(hostBase string, useHTTPS bool) string {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- Take logic from existing `rgw.NewClient` function and create two new functions `rgw.NewS3Client` and `rgw.NewSTSClient`. Call these functions to add new clients to backend when `backendmonitor_controller` reconciles.
- Add low level `AssumeRole` function, this is not yet called anywhere
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI - No real logic change as the STS Client is added to backend, but is not used.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
