### PR TITLE
Add --assume-role-arn flag and s3 client handler package

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -98,6 +98,8 @@ func main() {
 
 		autoPauseBucket = app.Flag("auto-pause-bucket", "Enable auto pause of reconciliation of ready buckets").Default("false").Envar("AUTO_PAUSE_BUCKET").Bool()
 
+		_ = app.Flag("assume-role-arn", "Assume role ARN to be used for STS authentication").Default("").Envar("ASSUME_ROLE_ARN").String()
+
 		webhookTLSCertDir = app.Flag("webhook-tls-cert-dir", "The directory of TLS certificate that will be used by the webhook server. There should be tls.crt and tls.key files.").Default("/").Envar("WEBHOOK_TLS_CERT_DIR").String()
 		_                 = app.Flag("enable-validation-webhooks", "Enable support for Webhooks. [Deprecated, has no effect]").Default("false").Bool()
 	)

--- a/hack/deploy-provider.sh
+++ b/hack/deploy-provider.sh
@@ -28,6 +28,7 @@ spec:
             - --reconcile-concurrency=160
             - --poll=30m
             - --sync=1h
+            - --assume-role-arn=arn:aws:iam:linode:role/provider-ceph
 EOF
 
 # Apply the provider.

--- a/internal/controller/bucket/connector.go
+++ b/internal/controller/bucket/connector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/linode/provider-ceph/internal/backendstore"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,6 +20,7 @@ type Connector struct {
 	autoPauseBucket     bool
 	backendStore        *backendstore.BackendStore
 	subresourceClients  []SubresourceClient
+	s3ClientHandler     *s3clienthandler.Handler
 	log                 logging.Logger
 	operationTimeout    time.Duration
 	creationGracePeriod time.Duration
@@ -84,6 +86,12 @@ func WithSubresourceClients(s []SubresourceClient) func(*Connector) {
 	}
 }
 
+func WithS3ClientHandler(h *s3clienthandler.Handler) func(*Connector) {
+	return func(c *Connector) {
+		c.s3ClientHandler = h
+	}
+}
+
 func WithLog(l logging.Logger) func(*Connector) {
 	return func(c *Connector) {
 		c.log = l
@@ -107,6 +115,7 @@ func (c *Connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			operationTimeout:   c.operationTimeout,
 			backendStore:       c.backendStore,
 			subresourceClients: c.subresourceClients,
+			s3ClientHandler:    c.s3ClientHandler,
 			log:                c.log},
 		nil
 }
@@ -119,5 +128,6 @@ type external struct {
 	operationTimeout   time.Duration
 	backendStore       *backendstore.BackendStore
 	subresourceClients []SubresourceClient
+	s3ClientHandler    *s3clienthandler.Handler
 	log                logging.Logger
 }

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -77,7 +77,13 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	for beName := range activeBackends {
 		originalBucket := bucket.DeepCopy()
 
-		cl := c.backendStore.GetBackendS3Client(beName)
+		cl, err := c.s3ClientHandler.GetS3Client(beName)
+		if err != nil {
+			traces.SetAndRecordError(span, err)
+			c.log.Info("Failed to get client for backend - bucket cannot be created on backend", consts.KeyBucketName, originalBucket.Name, consts.KeyBackendName, beName, "error", err.Error())
+
+			continue
+		}
 		if cl == nil {
 			c.log.Info("Backend client not found for backend - bucket cannot be created on backend", consts.KeyBucketName, originalBucket.Name, consts.KeyBackendName, beName)
 

--- a/internal/controller/bucket/create_test.go
+++ b/internal/controller/bucket/create_test.go
@@ -15,6 +15,7 @@ import (
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/backendstore/backendstorefakes"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -358,8 +359,11 @@ func TestCreate(t *testing.T) {
 			}
 
 			e := external{
-				kubeClient:       cl.Build(),
-				backendStore:     tc.fields.backendStore,
+				kubeClient:   cl.Build(),
+				backendStore: tc.fields.backendStore,
+				s3ClientHandler: s3clienthandler.NewHandler(
+					s3clienthandler.WithAssumeRoleArn(nil),
+					s3clienthandler.WithBackendStore(tc.fields.backendStore)),
 				log:              logging.NewNopLogger(),
 				operationTimeout: time.Second * 5,
 			}

--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -15,6 +15,7 @@ import (
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/consts"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 	"github.com/linode/provider-ceph/internal/otel/traces"
 	"github.com/linode/provider-ceph/internal/rgw"
 
@@ -26,13 +27,14 @@ import (
 
 // LifecycleConfigurationClient is the client for API methods and reconciling the LifecycleConfiguration
 type LifecycleConfigurationClient struct {
-	backendStore *backendstore.BackendStore
-	log          logging.Logger
+	backendStore    *backendstore.BackendStore
+	s3ClientHandler *s3clienthandler.Handler
+	log             logging.Logger
 }
 
 // NewLifecycleConfigurationClient creates the client for Accelerate Configuration
-func NewLifecycleConfigurationClient(backendStore *backendstore.BackendStore, log logging.Logger) *LifecycleConfigurationClient {
-	return &LifecycleConfigurationClient{backendStore: backendStore, log: log}
+func NewLifecycleConfigurationClient(b *backendstore.BackendStore, h *s3clienthandler.Handler, l logging.Logger) *LifecycleConfigurationClient {
+	return &LifecycleConfigurationClient{backendStore: b, s3ClientHandler: h, log: l}
 }
 
 func (l *LifecycleConfigurationClient) Observe(ctx context.Context, bucket *v1alpha1.Bucket, backendNames []string) (ResourceStatus, error) {

--- a/internal/controller/bucket/lifecycleconfiguration.go
+++ b/internal/controller/bucket/lifecycleconfiguration.go
@@ -187,9 +187,12 @@ func (l *LifecycleConfigurationClient) Handle(ctx context.Context, b *v1alpha1.B
 
 func (l *LifecycleConfigurationClient) createOrUpdate(ctx context.Context, b *v1alpha1.Bucket, backendName string) error {
 	l.log.Info("Updating lifecycle configuration", consts.KeyBucketName, b.Name, consts.KeyBackendName, backendName)
-	s3Client := l.backendStore.GetBackendS3Client(backendName)
+	s3Client, err := l.s3ClientHandler.GetS3Client(backendName)
+	if err != nil {
+		return err
+	}
 
-	_, err := rgw.PutBucketLifecycleConfiguration(ctx, s3Client, b)
+	_, err = rgw.PutBucketLifecycleConfiguration(ctx, s3Client, b)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/bucket/lifecycleconfiguration_test.go
+++ b/internal/controller/bucket/lifecycleconfiguration_test.go
@@ -33,6 +33,7 @@ import (
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/backendstore/backendstorefakes"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 	"github.com/linode/provider-ceph/internal/rgw"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -446,7 +447,13 @@ func TestObserveBackend(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			c := NewLifecycleConfigurationClient(tc.fields.backendStore, logging.NewNopLogger())
+			c := NewLifecycleConfigurationClient(
+				tc.fields.backendStore,
+				s3clienthandler.NewHandler(
+					s3clienthandler.WithAssumeRoleArn(nil),
+					s3clienthandler.WithBackendStore(tc.fields.backendStore)),
+				logging.NewNopLogger())
+
 			got, err := c.observeBackend(context.Background(), tc.args.bucket, tc.args.backendName)
 			require.ErrorIs(t, err, tc.want.err, "unexpected error")
 			assert.Equal(t, tc.want.status, got, "unexpected status")
@@ -749,7 +756,13 @@ func TestHandle(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			c := NewLifecycleConfigurationClient(tc.fields.backendStore, logging.NewNopLogger())
+			c := NewLifecycleConfigurationClient(
+				tc.fields.backendStore,
+				s3clienthandler.NewHandler(
+					s3clienthandler.WithAssumeRoleArn(nil),
+					s3clienthandler.WithBackendStore(tc.fields.backendStore)),
+				logging.NewNopLogger())
+
 			bb := newBucketBackends()
 			bb.setLifecycleConfigCondition(bucketName, beName, &creating)
 

--- a/internal/controller/bucket/subresources.go
+++ b/internal/controller/bucket/subresources.go
@@ -23,6 +23,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 )
 
 // SubresourceClient is the interface all Bucket sub-resources must conform to.
@@ -32,9 +33,9 @@ type SubresourceClient interface {
 }
 
 // NewSubresourceClients creates the array of all sub resource clients.
-func NewSubresourceClients(backendStore *backendstore.BackendStore, log logging.Logger) []SubresourceClient {
+func NewSubresourceClients(b *backendstore.BackendStore, h *s3clienthandler.Handler, l logging.Logger) []SubresourceClient {
 	return []SubresourceClient{
-		NewLifecycleConfigurationClient(backendStore, log.WithValues("lifecycle-configuration-client", managed.ControllerName(v1alpha1.BucketGroupKind))),
+		NewLifecycleConfigurationClient(b, h, l.WithValues("lifecycle-configuration-client", managed.ControllerName(v1alpha1.BucketGroupKind))),
 	}
 }
 

--- a/internal/controller/bucket/update_test.go
+++ b/internal/controller/bucket/update_test.go
@@ -15,6 +15,7 @@ import (
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/backendstore/backendstorefakes"
+	"github.com/linode/provider-ceph/internal/controller/s3clienthandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -394,8 +395,11 @@ func TestUpdate(t *testing.T) {
 				WithScheme(s).Build()
 
 			e := external{
-				kubeClient:      cl,
-				backendStore:    tc.fields.backendStore,
+				kubeClient:   cl,
+				backendStore: tc.fields.backendStore,
+				s3ClientHandler: s3clienthandler.NewHandler(
+					s3clienthandler.WithAssumeRoleArn(nil),
+					s3clienthandler.WithBackendStore(tc.fields.backendStore)),
 				autoPauseBucket: tc.fields.autoPauseBucket,
 				log:             logging.NewNopLogger(),
 			}

--- a/internal/controller/s3clienthandler/s3clienthandler.go
+++ b/internal/controller/s3clienthandler/s3clienthandler.go
@@ -45,3 +45,11 @@ func WithLog(l logging.Logger) func(*Handler) {
 		c.log = l
 	}
 }
+
+func (c *Handler) GetS3Client(backendName string) (backendstore.S3Client, error) {
+	// TODO: We should only return the existing backend s3 client if the user has not
+	// specified --assume-role-arn. Otherwise, we should use the backend's STS client
+	// perform AssumeRole and use the response credentials to buld a temporary S3 client
+	// for the operation being undertaken.
+	return c.backendStore.GetBackendS3Client(backendName), nil
+}

--- a/internal/controller/s3clienthandler/s3clienthandler.go
+++ b/internal/controller/s3clienthandler/s3clienthandler.go
@@ -1,0 +1,47 @@
+package s3clienthandler
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/linode/provider-ceph/internal/backendstore"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Handler struct {
+	kubeClient    client.Client
+	assumeRoleArn *string
+	backendStore  *backendstore.BackendStore
+	log           logging.Logger
+}
+
+func NewHandler(options ...func(*Handler)) *Handler {
+	c := &Handler{}
+	for _, o := range options {
+		o(c)
+	}
+
+	return c
+}
+
+func WithKubeClient(k client.Client) func(*Handler) {
+	return func(c *Handler) {
+		c.kubeClient = k
+	}
+}
+
+func WithAssumeRoleArn(a *string) func(*Handler) {
+	return func(c *Handler) {
+		c.assumeRoleArn = a
+	}
+}
+
+func WithBackendStore(s *backendstore.BackendStore) func(*Handler) {
+	return func(c *Handler) {
+		c.backendStore = s
+	}
+}
+
+func WithLog(l logging.Logger) func(*Handler) {
+	return func(c *Handler) {
+		c.log = l
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- Add flag `--assume-role-arn` for user to specify the Role ARN for the AssumeRole request.
- Set this flag in the deploy script - for now, this will has effect om existing functionality.
- Add `s3clienthandler` package and pass instance to bucket controllers - this will be used for create, update and subresource update calls to create a new S3 client via the STS client AssumeRole credentials. The logic is not implemented in this PR, we simply shortcircuit to the existing S3 client for the backend in question.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI, some unit test edits to avoid NPEs - no real logic change included in this PR 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
