### PR TITLE
Add security token header to S3 client

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -8,4 +8,7 @@ const (
 	// Secret keys.
 	KeyAccessKey = "access_key"
 	KeySecretKey = "secret_key"
+
+	// API request header keys.
+	KeySecurityToken = "x-amz-security-token"
 )

--- a/internal/controller/providerconfig/backendmonitor/backendmonitor_controller.go
+++ b/internal/controller/providerconfig/backendmonitor/backendmonitor_controller.go
@@ -77,7 +77,7 @@ func (c *Controller) addOrUpdateBackend(ctx context.Context, pc *apisv1alpha1.Pr
 		return err
 	}
 
-	s3Client, err := rgw.NewS3Client(ctx, secret.Data, &pc.Spec, c.s3Timeout)
+	s3Client, err := rgw.NewS3Client(ctx, secret.Data, &pc.Spec, c.s3Timeout, nil)
 	if err != nil {
 		return errors.Wrap(err, errCreateS3Client)
 	}

--- a/internal/controller/s3clienthandler/s3clienthandler.go
+++ b/internal/controller/s3clienthandler/s3clienthandler.go
@@ -110,7 +110,10 @@ func (h *Handler) createAssumeRoleS3Client(ctx context.Context, b *v1alpha1.Buck
 		return nil, errors.Wrap(err, errFailedToCreateAssumeRoleS3Client.Error())
 	}
 
-	if resp.Credentials == nil || resp.Credentials.AccessKeyId == nil || resp.Credentials.SecretAccessKey == nil {
+	if resp.Credentials == nil ||
+		resp.Credentials.AccessKeyId == nil ||
+		resp.Credentials.SecretAccessKey == nil ||
+		resp.Credentials.SessionToken == nil {
 		return nil, errors.Wrap(errNoCreds, errFailedToCreateAssumeRoleS3Client.Error())
 	}
 
@@ -123,7 +126,7 @@ func (h *Handler) createAssumeRoleS3Client(ctx context.Context, b *v1alpha1.Buck
 		return nil, errors.Wrap(err, errFailedToCreateAssumeRoleS3Client.Error())
 	}
 
-	s3Client, err := rgw.NewS3Client(ctx, data, &pc.Spec, h.s3Timeout)
+	s3Client, err := rgw.NewS3Client(ctx, data, &pc.Spec, h.s3Timeout, resp.Credentials.SessionToken)
 	if err != nil {
 		return nil, errors.Wrap(err, errFailedToCreateAssumeRoleS3Client.Error())
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The header `x-amz-security-token` needs to be included for the S3 client created by AssumeRole. For the "generic" S3 client created using the secret credentials, this can be omitted.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
