### PR TITLE
Use assume role client everywhere

### DIFF
--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -84,11 +84,6 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 			continue
 		}
-		if cl == nil {
-			c.log.Info("Backend client not found for backend - bucket cannot be created on backend", consts.KeyBucketName, originalBucket.Name, consts.KeyBackendName, beName)
-
-			continue
-		}
 
 		c.log.Info("Creating bucket on backend", consts.KeyBucketName, originalBucket.Name, consts.KeyBackendName, beName)
 

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -138,11 +138,7 @@ func (c *external) updateOnAllBackends(ctx context.Context, bucket *v1alpha1.Buc
 
 			continue
 		}
-		if cl == nil {
-			c.log.Info("Backend client not found for backend - bucket cannot be updated on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
 
-			continue
-		}
 		beName := backendName
 		g.Go(func() error {
 			c.log.Info("Updating bucket on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)

--- a/internal/controller/s3clienthandler/s3clienthandler.go
+++ b/internal/controller/s3clienthandler/s3clienthandler.go
@@ -80,7 +80,12 @@ func (h *Handler) GetS3Client(ctx context.Context, b *v1alpha1.Bucket, backendNa
 		return h.createAssumeRoleS3Client(ctx, b, backendName)
 	}
 
-	return h.backendStore.GetBackendS3Client(backendName), nil
+	cl := h.backendStore.GetBackendS3Client(backendName)
+	if cl == nil {
+		return nil, errors.New("No S3 client found for backend")
+	}
+
+	return cl, nil
 }
 
 func (h *Handler) createAssumeRoleS3Client(ctx context.Context, b *v1alpha1.Bucket, backendName string) (backendstore.S3Client, error) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Originally we had planned to only use AssumeRole for Create and Update calls. However Delete and LifecycleConfig calls also use lower level S3 calls such as `HeadBucket` which require the same permissions as Create and Update calls... Therefore it is simplest to use AssumeRole in all situations where a role-arn is specified.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manual Create/Delete buckets vs OBJ + existing CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
