### PR TITLE
Fix nilcheck by ignoring LCC helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,8 +288,9 @@ NILAWAY := $(TOOLS_HOST_DIR)/nilaway-$(NILAWAY_VERSION)
 nilcheck: $(NILAWAY) ## Run nil check against codemake.
 	@# The bucket_backends.go is nil safe, covered by tests.
 	@# Backendstore contains mostly nil safe generated files.
+	@# Lifecycleconfig_helper has false positive reports: https://github.com/uber-go/nilaway/issues/207
 	go list ./... | xargs -I {} -d '\n' $(NILAWAY) \
-		-exclude-errors-in-files $(PWD)/internal/controller/bucket/bucket_backends.go \
+		-exclude-errors-in-files $(PWD)/internal/controller/bucket/bucket_backends.go,$(PWD)/internal/rgw/lifecycleconfig_helpers.go \
 		-exclude-pkgs github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1,github.com/linode/provider-ceph/internal/backendstore \
 		-include-pkgs {} ./...
 


### PR DESCRIPTION
This change workarounds a false positive report of nilaway: https://github.com/uber-go/nilaway/issues/207