### PR TITLE
Ability to run webhook locally

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,6 +1,0 @@
-.git/
-.github/
-.husky/
-.vscode/
-bin/
-kind-logs-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /bin
 /.cache
 /.work
-/.tmp-earthly*
 /_output
 cover.out
 /vendor

--- a/.husky/husky.mk
+++ b/.husky/husky.mk
@@ -1,7 +1,11 @@
-
 HUSKY_VERSION ?= v0.2.16
 HUSKY ?= $(TOOLS_HOST_DIR)/husky-$(HUSKY_VERSION)
-husky: ## Download husky locally if necessary.
+
+husky.install: $(HUSKY)
+	@$(HUSKY) install
+
+## Download husky locally if necessary.
+$(HUSKY):
 	@$(INFO) installing husky $(HUSKY_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR)
 	@GOBIN=$(TOOLS_HOST_DIR) go install github.com/automation-co/husky@$(HUSKY_VERSION)

--- a/.mirrord/mirrord.mk
+++ b/.mirrord/mirrord.mk
@@ -1,7 +1,14 @@
-MIRRORD_VERSION ?= 3.70.0
+MIRRORD_VERSION ?= 3.88.0
 MIRRORD := $(TOOLS_HOST_DIR)/mirrord-$(MIRRORD_VERSION)
 
-# mirrord download and install
+# Best for development - locally run provider-ceph controller.
+mirrord.cluster: dev-cluster crossplane-cluster load-package
+
+mirrord.run: $(MIRRORD)
+	@$(INFO) Starting mirrord on deployment
+	$(MIRRORD) exec -f .mirrord/mirrord.json make run
+
+# Download mirrord locally if necessary.
 $(MIRRORD):
 	@$(INFO) installing mirrord $(MIRRORD_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR) || $(FAIL)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ with the following features:
 - A controller that observes `Bucket` objects and reconciles these objects with the S3 backends.
 
 ## Developing
+
 Spin up the test environment, but with `provider-ceph` running locally in your terminal:
 
 ```
@@ -21,6 +22,15 @@ After you've made some changes, kill (Ctrl+C) the existing `provider-ceph` and r
 ```
 make run
 ```
+
+### Debugging
+Spin up the test environment, but with `provider-ceph` running locally in your terminal:
+
+```
+make mirrord.cluster mirrord.run
+```
+
+For debugging please install `mirrord` plugin in your IDE of choice.
 
 Refer to Crossplane's [CONTRIBUTING.md] file for more information on how the
 Crossplane community prefers to work. The [Provider Development][provider-dev]

--- a/hack/localtunnel.yaml
+++ b/hack/localtunnel.yaml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  # Socat proxies localtunnel requests to webhook service
+  provider-ceph-socat:
+    image: nixery.dev/socat
+    command: socat TCP-LISTEN:${WEBHOOK_TUNNEL_PORT},reuseaddr,fork OPENSSL:${WEBHOOK_HOST}:9443,verify=0
+    network_mode: "host"
+    container_name: provider-ceph-socat
+    restart: unless-stopped
+
+  # Localtunnel creates an external domain with valid certificate
+  provider-ceph-localtunnel:
+    image: nixery.dev/nodepackages.localtunnel
+    command: lt --subdomain ${WEBHOOK_SUBDOMAIN} --port ${WEBHOOK_TUNNEL_PORT}
+    network_mode: "host"
+    container_name: provider-ceph-localtunnel
+    restart: unless-stopped

--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -7,9 +7,10 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: provider-ceph
+      namespace: crossplane-system
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
+      port: 9443
   failurePolicy: Fail
   name: bucket-validation.providerceph.crossplane.io
   objectSelector:

--- a/staging/validatingwebhookconfiguration/.gitignore
+++ b/staging/validatingwebhookconfiguration/.gitignore
@@ -1,0 +1,1 @@
+manifests.yaml

--- a/staging/validatingwebhookconfiguration/kustomization.yaml
+++ b/staging/validatingwebhookconfiguration/kustomization.yaml
@@ -2,6 +2,9 @@ resources:
 - manifests.yaml
 
 patches:
-- path: patch.yaml
+- path: object-selector-patch.yaml
+  target:
+    kind: ValidatingWebhookConfiguration
+- path: service-patch.yaml
   target:
     kind: ValidatingWebhookConfiguration

--- a/staging/validatingwebhookconfiguration/object-selector-patch.yaml
+++ b/staging/validatingwebhookconfiguration/object-selector-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: bucket-validation.providerceph.crossplane.io
+  objectSelector:
+    matchLabels:
+      provider-ceph.crossplane.io/validation-required: "true"

--- a/staging/validatingwebhookconfiguration/service-patch-dev.tpl.yaml
+++ b/staging/validatingwebhookconfiguration/service-patch-dev.tpl.yaml
@@ -1,0 +1,5 @@
+- op: remove
+  path: /webhooks/0/clientConfig/service
+- op: add
+  path: /webhooks/0/clientConfig/url
+  value: https://#WEBHOOK_HOST#/validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket

--- a/staging/validatingwebhookconfiguration/service-patch-prod.yaml
+++ b/staging/validatingwebhookconfiguration/service-patch-prod.yaml
@@ -4,6 +4,8 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - name: bucket-validation.providerceph.crossplane.io
-  objectSelector:
-    matchLabels:
-      provider-ceph.crossplane.io/validation-required: "true" 
+  clientConfig:
+    service:
+      name: provider-ceph
+      namespace: crossplane-system
+      port: 9443

--- a/staging/validatingwebhookconfiguration/service-patch.yaml
+++ b/staging/validatingwebhookconfiguration/service-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: bucket-validation.providerceph.crossplane.io
+  clientConfig:
+    service:
+      name: provider-ceph
+      namespace: crossplane-system
+      port: 9443


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change gives the power of running the webhook outside the Kubernetes cluster.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
