### PR TITLE
Fix unpause buckets and recreate if missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 cover.out
 /vendor
 /.vendor-new
+__debug*
 .vscode
 .idea
 .DS_Store

--- a/internal/controller/bucket/consts.go
+++ b/internal/controller/bucket/consts.go
@@ -19,4 +19,6 @@ const (
 	// Lifecycle configuration error messages.
 	errObserveLifecycleConfig = "failed to observe bucket lifecycle configuration"
 	errHandleLifecycleConfig  = "failed to handle bucket lifecycle configuration"
+
+	True = "true"
 )

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/linode/provider-ceph/internal/consts"
 	"github.com/linode/provider-ceph/internal/otel/traces"
 	"github.com/linode/provider-ceph/internal/rgw"
+	"github.com/linode/provider-ceph/internal/utils"
 )
 
 //nolint:maintidx,gocognit,gocyclo,cyclop,nolintlint // Function requires numerous checks.
@@ -49,10 +50,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, err
 	}
 
-	providerNames := bucket.Spec.Providers
-	if len(providerNames) == 0 {
-		providerNames = c.backendStore.GetAllActiveBackendNames()
-	}
+	providerNames := utils.GetBucketProvidersFilterDisabledLabel(bucket, c.backendStore.GetAllActiveBackendNames())
 
 	// Create the bucket on each backend in a separate go routine
 	activeBackends := c.backendStore.GetActiveBackends(providerNames)

--- a/internal/controller/bucket/create.go
+++ b/internal/controller/bucket/create.go
@@ -164,7 +164,7 @@ func (c *external) waitForCreationAndUpdateBucketCR(ctx context.Context, bucket 
 				if bucketLatest.ObjectMeta.Labels == nil {
 					bucketLatest.ObjectMeta.Labels = map[string]string{}
 				}
-				bucketLatest.ObjectMeta.Labels[v1alpha1.BackendLabelPrefix+beName] = "true"
+				bucketLatest.ObjectMeta.Labels[v1alpha1.BackendLabelPrefix+beName] = True
 
 				return NeedsObjectUpdate
 			}, func(_, bucketLatest *v1alpha1.Bucket) UpdateRequired {

--- a/internal/controller/bucket/create_test.go
+++ b/internal/controller/bucket/create_test.go
@@ -76,47 +76,6 @@ func TestCreateBasicErrors(t *testing.T) {
 				err: errors.New(errNoActiveS3Backends),
 			},
 		},
-		"S3 backend reference inactive": {
-			fields: fields{
-				backendStore: func() *backendstore.BackendStore {
-					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-0", nil, nil, true, apisv1alpha1.HealthStatusUnknown)
-					bs.AddOrUpdateBackend("s3-backend-1", nil, nil, false, apisv1alpha1.HealthStatusUnknown)
-
-					return bs
-				}(),
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					Spec: v1alpha1.BucketSpec{
-						Providers: []string{"s3-backend-0", "s3-backend-1"},
-					},
-				},
-			},
-			want: want{
-				err: errors.New(errMissingS3Backend),
-			},
-		},
-		"S3 backend reference missing": {
-			fields: fields{
-				backendStore: func() *backendstore.BackendStore {
-					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-0", nil, nil, true, apisv1alpha1.HealthStatusUnknown)
-
-					return bs
-				}(),
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					Spec: v1alpha1.BucketSpec{
-						Providers: []string{"s3-backend-0", "s3-backend-1"},
-					},
-				},
-			},
-			want: want{
-				err: errors.New(errMissingS3Backend),
-			},
-		},
 		"S3 backend not referenced and none exist": {
 			fields: fields{
 				backendStore: backendstore.NewBackendStore(),

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -45,12 +45,12 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	g := new(errgroup.Group)
 
-	activeBackends := bucket.Spec.Providers
-	if len(activeBackends) == 0 {
-		activeBackends = c.backendStore.GetAllActiveBackendNames()
+	providerNames := bucket.Spec.Providers
+	if len(providerNames) == 0 {
+		providerNames = c.backendStore.GetAllActiveBackendNames()
 	}
 
-	for _, backendName := range activeBackends {
+	for _, backendName := range providerNames {
 		bucketBackends.setBucketCondition(bucket.Name, backendName, xpv1.Deleting())
 
 		c.log.Info("Deleting bucket on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
@@ -89,8 +89,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	// CR spec. If the deletion is successful or unsuccessful, the bucket CR status must be
 	// updated.
 	if err := c.updateBucketCR(ctx, bucket, func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
-		bucketLatest.Spec.Providers = activeBackends
-		setBucketStatus(bucketLatest, bucketBackends)
+		setBucketStatus(bucketLatest, bucketBackends, providerNames)
 
 		return NeedsStatusUpdate
 	}); err != nil {

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -19,7 +19,7 @@ import (
 
 // isBucketPaused returns true if the bucket has the paused label set.
 func isBucketPaused(bucket *v1alpha1.Bucket) bool {
-	if val, ok := bucket.Labels[meta.AnnotationKeyReconciliationPaused]; ok && val == "true" {
+	if val, ok := bucket.Labels[meta.AnnotationKeyReconciliationPaused]; ok && val == True {
 		return true
 	}
 
@@ -31,7 +31,7 @@ func pauseBucket(bucket *v1alpha1.Bucket) {
 	if bucket.ObjectMeta.Labels == nil {
 		bucket.ObjectMeta.Labels = map[string]string{}
 	}
-	bucket.Labels[meta.AnnotationKeyReconciliationPaused] = "true"
+	bucket.Labels[meta.AnnotationKeyReconciliationPaused] = True
 }
 
 // isPauseRequired determines if the Bucket should be paused.
@@ -90,7 +90,7 @@ func setBackendLabels(bucket *v1alpha1.Bucket, providerNames []string) {
 
 	labelsToDelete := []string{}
 	for k := range bucket.ObjectMeta.Labels {
-		if strings.HasPrefix(k, v1alpha1.BackendLabelPrefix) {
+		if strings.HasPrefix(k, v1alpha1.BackendLabelPrefix) && bucket.ObjectMeta.Labels[k] == True {
 			labelsToDelete = append(labelsToDelete, k)
 		}
 	}
@@ -104,7 +104,7 @@ func setBackendLabels(bucket *v1alpha1.Bucket, providerNames []string) {
 			continue
 		}
 
-		bucket.ObjectMeta.Labels[beLabel] = "true"
+		bucket.ObjectMeta.Labels[beLabel] = True
 	}
 }
 

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/consts"
+	"github.com/linode/provider-ceph/internal/utils"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -99,7 +100,7 @@ func setBackendLabels(bucket *v1alpha1.Bucket, providerNames []string) {
 	}
 
 	for _, beName := range providerNames {
-		beLabel := v1alpha1.BackendLabelPrefix + beName
+		beLabel := utils.GetBackendLabel(beName)
 		if _, ok := bucket.ObjectMeta.Labels[beLabel]; ok {
 			continue
 		}

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -67,13 +67,20 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	// If no Providers are specified in the Bucket Spec, the bucket is to be created on all backends.
-	if len(bucket.Spec.Providers) == 0 {
-		bucket.Spec.Providers = c.backendStore.GetAllActiveBackendNames()
+	providerNames := bucket.Spec.Providers
+	if len(providerNames) == 0 {
+		providerNames = c.backendStore.GetAllActiveBackendNames()
 	}
-	backendClients := c.backendStore.GetBackendS3Clients(bucket.Spec.Providers)
+	if len(providerNames) == 0 {
+		err := errors.New(errNoActiveS3Backends)
+		traces.SetAndRecordError(span, err)
+
+		return managed.ExternalObservation{}, err
+	}
+	backendClients := c.backendStore.GetBackendS3Clients(providerNames)
 
 	// Check that the Bucket CR is Available according to its Status backends.
-	if !isBucketAvailableFromStatus(bucket, backendClients) {
+	if !isBucketAvailableFromStatus(bucket, providerNames, backendClients) {
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,
@@ -82,7 +89,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	// Observe sub-resources for the Bucket to check if they too are up to date.
 	for _, subResourceClient := range c.subresourceClients {
-		obs, err := subResourceClient.Observe(ctx, bucket, bucket.Spec.Providers)
+		obs, err := subResourceClient.Observe(ctx, bucket, providerNames)
 		if err != nil {
 			err := errors.Wrap(err, errObserveSubresource)
 			traces.SetAndRecordError(span, err)

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -16,6 +16,7 @@ import (
 	"github.com/linode/provider-ceph/internal/consts"
 	"github.com/linode/provider-ceph/internal/otel/traces"
 	"github.com/linode/provider-ceph/internal/rgw"
+	"github.com/linode/provider-ceph/internal/utils"
 )
 
 //nolint:gocyclo,cyclop // Function requires numerous checks.
@@ -67,10 +68,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	// If no Providers are specified in the Bucket Spec, the bucket is to be created on all backends.
-	providerNames := bucket.Spec.Providers
-	if len(providerNames) == 0 {
-		providerNames = c.backendStore.GetAllActiveBackendNames()
-	}
+	providerNames := utils.GetBucketProvidersFilterDisabledLabel(bucket, c.backendStore.GetAllActiveBackendNames())
 	if len(providerNames) == 0 {
 		err := errors.New(errNoActiveS3Backends)
 		traces.SetAndRecordError(span, err)

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -164,11 +164,11 @@ func (c *external) updateOnBackend(ctx context.Context, beName string, bucket *v
 
 			_, err := rgw.CreateBucket(ctx, cl, rgw.BucketToCreateBucketInput(bucket))
 			if err != nil {
-				c.log.Info("Failed to create bucket on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName, "err", err.Error())
+				c.log.Info("Failed to recreate missing bucket on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName, "err", err.Error())
 
 				return err
 			}
-			c.log.Info("Bucket created on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)
+			c.log.Info("Recreated missing bucket on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, beName)
 		}
 
 		err = c.doUpdateOnBackend(ctx, cl, bucket, beName, bb)

--- a/internal/controller/bucket/update_test.go
+++ b/internal/controller/bucket/update_test.go
@@ -92,36 +92,6 @@ func TestUpdateBasicErrors(t *testing.T) {
 				err: errors.New(errNoActiveS3Backends),
 			},
 		},
-		"Missing backend": {
-			fields: fields{
-				backendStore: func() *backendstore.BackendStore {
-					fake := backendstorefakes.FakeS3Client{
-						HeadBucketStub: func(ctx context.Context, hbi *s3.HeadBucketInput, f ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
-							return &s3.HeadBucketOutput{}, nil
-						},
-					}
-
-					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-1", &fake, nil, true, apisv1alpha1.HealthStatusHealthy)
-
-					return bs
-				}(),
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					Spec: v1alpha1.BucketSpec{
-						Providers: []string{
-							"s3-backend-1",
-							"s3-backend-2",
-						},
-					},
-				},
-			},
-			want: want{
-				o:   managed.ExternalUpdate{},
-				err: errors.New(errMissingS3Backend),
-			},
-		},
 	}
 	for name, tc := range cases {
 		tc := tc
@@ -413,7 +383,7 @@ func TestUpdate(t *testing.T) {
 					assert.Equal(t,
 						map[string]string{
 							meta.AnnotationKeyReconciliationPaused: "true",
-							"provider-ceph.backends.s3-backend-1":  "",
+							"provider-ceph.backends.s3-backend-1":  "true",
 						},
 						bucket.Labels,
 						"unexpected bucket labels",

--- a/internal/controller/bucket/update_test.go
+++ b/internal/controller/bucket/update_test.go
@@ -382,8 +382,8 @@ func TestUpdate(t *testing.T) {
 
 					assert.Equal(t,
 						map[string]string{
-							meta.AnnotationKeyReconciliationPaused: "true",
-							"provider-ceph.backends.s3-backend-1":  "true",
+							meta.AnnotationKeyReconciliationPaused: True,
+							"provider-ceph.backends.s3-backend-1":  True,
 						},
 						bucket.Labels,
 						"unexpected bucket labels",

--- a/internal/controller/providerconfig/healthcheck/healthcheck.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Controller struct {
-	kubeClient      client.Client
-	backendStore    *backendstore.BackendStore
-	log             logging.Logger
-	autoPauseBucket bool
+	kubeClientUncached client.Client
+	kubeClientCached   client.Client
+	backendStore       *backendstore.BackendStore
+	log                logging.Logger
+	autoPauseBucket    bool
 }
 
 func NewController(options ...func(*Controller)) *Controller {
@@ -26,9 +27,15 @@ func NewController(options ...func(*Controller)) *Controller {
 	return r
 }
 
-func WithKubeClient(k client.Client) func(*Controller) {
+func WithKubeClientUncached(k client.Client) func(*Controller) {
 	return func(r *Controller) {
-		r.kubeClient = k
+		r.kubeClientUncached = k
+	}
+}
+
+func WithKubeClientCached(k client.Client) func(*Controller) {
+	return func(r *Controller) {
+		r.kubeClientCached = k
 	}
 }
 

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
@@ -57,6 +57,8 @@ const (
 	errBackendNotStored         = "backend is not stored in backendstore"
 	healthCheckSuffix           = "-health-check"
 	healthCheckFile             = "health-check-file"
+
+	True = "true"
 )
 
 //nolint:gocyclo,cyclop // Function requires multiple checks.
@@ -277,8 +279,8 @@ func (c *Controller) unpauseBuckets(ctx context.Context, s3BackendName string) {
 	// Only list Buckets that (a) were created on s3BackendName
 	// and (b) are already paused.
 	listLabels := labels.SelectorFromSet(labels.Set(map[string]string{
-		v1alpha1.BackendLabelPrefix + s3BackendName: "true",
-		meta.AnnotationKeyReconciliationPaused:      "true",
+		v1alpha1.BackendLabelPrefix + s3BackendName: True,
+		meta.AnnotationKeyReconciliationPaused:      True,
 	}))
 
 	buckets := &v1alpha1.BucketList{}
@@ -308,7 +310,7 @@ func (c *Controller) unpauseBuckets(ctx context.Context, s3BackendName string) {
 			Jitter:   jitter,
 		}, resource.IsAPIError, func() error {
 			if (c.autoPauseBucket || buckets.Items[i].Spec.AutoPause) &&
-				buckets.Items[i].Labels[meta.AnnotationKeyReconciliationPaused] == "true" {
+				buckets.Items[i].Labels[meta.AnnotationKeyReconciliationPaused] == True {
 				buckets.Items[i].Labels[meta.AnnotationKeyReconciliationPaused] = ""
 
 				return c.kubeClientCached.Update(ctx, &buckets.Items[i])

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
@@ -279,8 +279,8 @@ func (c *Controller) unpauseBuckets(ctx context.Context, s3BackendName string) {
 	// Only list Buckets that (a) were created on s3BackendName
 	// and (b) are already paused.
 	listLabels := labels.SelectorFromSet(labels.Set(map[string]string{
-		v1alpha1.BackendLabelPrefix + s3BackendName: True,
-		meta.AnnotationKeyReconciliationPaused:      True,
+		utils.GetBackendLabel(s3BackendName):   True,
+		meta.AnnotationKeyReconciliationPaused: True,
 	}))
 
 	buckets := &v1alpha1.BucketList{}

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
@@ -31,6 +31,7 @@ import (
 	apisv1alpha1 "github.com/linode/provider-ceph/apis/v1alpha1"
 	"github.com/linode/provider-ceph/internal/backendstore"
 	"github.com/linode/provider-ceph/internal/backendstore/backendstorefakes"
+	"github.com/linode/provider-ceph/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -407,8 +408,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-1",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "true",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "true",
 								},
 							},
 						},
@@ -416,8 +417,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-2",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "true",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "true",
 								},
 							},
 						},
@@ -425,8 +426,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-3",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -474,8 +475,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-1",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -483,8 +484,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-2",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -492,8 +493,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-3",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -535,8 +536,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-1",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "true",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "true",
 								},
 							},
 						},
@@ -544,8 +545,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-2",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "true",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "true",
 								},
 							},
 						},
@@ -553,8 +554,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-3",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -602,8 +603,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-1",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -611,8 +612,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-2",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},
@@ -620,8 +621,8 @@ func TestReconcile(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "bucket-3",
 								Labels: map[string]string{
-									v1alpha1.BackendLabelPrefix + backendName: "true",
-									meta.AnnotationKeyReconciliationPaused:    "",
+									utils.GetBackendLabel(backendName):     "true",
+									meta.AnnotationKeyReconciliationPaused: "",
 								},
 							},
 						},

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
@@ -672,7 +672,8 @@ func TestReconcile(t *testing.T) {
 			r := NewController(
 				WithAutoPause(&tc.fields.autopause),
 				WithBackendStore(bs),
-				WithKubeClient(c),
+				WithKubeClientUncached(c),
+				WithKubeClientCached(c),
 				WithLogger(logging.NewNopLogger()))
 
 			got, err := r.Reconcile(context.Background(), tc.args.req)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -27,3 +27,28 @@ func MapConditionToHealthStatus(condition commonv1.Condition) apisv1alpha1.Healt
 
 	return apisv1alpha1.HealthStatusUnknown
 }
+
+// GetBucketProvidersFilterDisabledLabel returns the specified providers or default providers,
+// and filters out providers disabledby label.
+func GetBucketProvidersFilterDisabledLabel(bucket *v1alpha1.Bucket, backends []string) []string {
+	providers := bucket.Spec.Providers
+	if len(providers) == 0 {
+		providers = backends
+	}
+
+	okProviders := []string{}
+	for i := range providers {
+		if status, ok := bucket.Labels[GetBackendLabel(providers[i])]; ok && status != "true" {
+			continue
+		}
+
+		okProviders = append(okProviders, providers[i])
+	}
+
+	return okProviders
+}
+
+// GetBackendLabel renders label key for provider.
+func GetBackendLabel(provider string) string {
+	return v1alpha1.BackendLabelPrefix + provider
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change fixes how backend recovery is handled. Fixes unpause bucket by using an uncached kube client. Fixing backend labeling of a bucket, because perviously only the first backend label was created (setting the label to `false` ignores backend for provider). This change adds a new cli flag to recreate existing bucket if missing. Also fixes delete process, and now it iterates on backends where the bucket is available instead of actual active backends.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
