### PR TITLE
Add error handling if non-healthcheck bucket is not empty

### DIFF
--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -123,6 +123,24 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 		c.log.Info("Failed to delete bucket on one or more backends", "error", deleteErr.Error())
 		traces.SetAndRecordError(span, deleteErr)
 
+		// If the error is BucketNotEmpty error, the DeleteBucket operation should be failed
+		// and the client should be able to use the bucket with non-empty buckends.
+		if errors.Is(deleteErr, rgw.ErrBucketNotEmpty) {
+			if err := c.updateBucketCR(ctx, bucket, func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
+				c.log.Info("Change 'disabled' flag to false", consts.KeyBucketName, bucket.Name)
+
+				bucketLatest.Spec.Disabled = false
+
+				return NeedsObjectUpdate
+			}); err != nil {
+				err = errors.Wrap(err, errUpdateBucketCR)
+				c.log.Info("Failed to change 'disabled' flag to false", consts.KeyBackendName, bucket.Name, "error", err.Error())
+				traces.SetAndRecordError(span, err)
+
+				return err
+			}
+		}
+
 		return deleteErr
 	}
 

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -80,7 +80,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 				return err
 			}
 
-			if err := rgw.DeleteBucket(ctx, cl, aws.String(bucket.Name)); err != nil {
+			if err := rgw.DeleteBucket(ctx, cl, aws.String(bucket.Name), false); err != nil {
 				bucketBackends.setBucketCondition(bucket.Name, beName, xpv1.Deleting().WithMessage(err.Error()))
 
 				return err

--- a/internal/controller/bucket/delete_test.go
+++ b/internal/controller/bucket/delete_test.go
@@ -701,8 +701,8 @@ func TestDelete(t *testing.T) {
 						"s3-backend-2 should not exist in backends")
 
 					// If backend deletion fails due to BucketNotEmpty error, Disabled flag should be false.
-					assert.True(t,
-						!bucket.Spec.Disabled,
+					assert.False(t,
+						bucket.Spec.Disabled,
 						"Disabled flag should be false",
 					)
 				},

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller.go
@@ -212,7 +212,7 @@ func (c *Controller) cleanup(ctx context.Context, req ctrl.Request, bucketName s
 	g := new(errgroup.Group)
 	g.Go(func() error {
 		c.log.Info("Deleting health check bucket", consts.KeyBucketName, bucketName, consts.KeyBackendName, req.Name)
-		if err := rgw.DeleteBucket(ctx, backendClient, aws.String(bucketName)); err != nil {
+		if err := rgw.DeleteBucket(ctx, backendClient, aws.String(bucketName), true); err != nil {
 			return errors.Wrap(err, errDeleteHealthCheckBucket)
 		}
 
@@ -221,7 +221,7 @@ func (c *Controller) cleanup(ctx context.Context, req ctrl.Request, bucketName s
 
 	g.Go(func() error {
 		c.log.Info("Deleting lifecycle configuration validation bucket", consts.KeyBucketName, v1alpha1.LifecycleConfigValidationBucketName, consts.KeyBackendName, req.Name)
-		if err := rgw.DeleteBucket(ctx, backendClient, aws.String(v1alpha1.LifecycleConfigValidationBucketName)); err != nil {
+		if err := rgw.DeleteBucket(ctx, backendClient, aws.String(v1alpha1.LifecycleConfigValidationBucketName), true); err != nil {
 			return errors.Wrap(err, errDeleteLCValidationBucket)
 		}
 

--- a/internal/rgw/bucket_helpers.go
+++ b/internal/rgw/bucket_helpers.go
@@ -92,3 +92,23 @@ func IsNotEmpty(err error) bool {
 
 	return ae != nil && ae.ErrorCode() == "BucketNotEmpty"
 }
+
+// Unlike NoSuchBucket error or others, aws-sdk-go-v2 doesn't have a specific struct definition for BucketNotEmpty error.
+// So we should define ourselves. This is currently only for testing.
+type BucketNotEmptyError struct{}
+
+func (e BucketNotEmptyError) Error() string {
+	return "BucketNotEmpty: some error"
+}
+
+func (e BucketNotEmptyError) ErrorCode() string {
+	return "BucketNotEmpty"
+}
+
+func (e BucketNotEmptyError) ErrorMessage() string {
+	return "some error"
+}
+
+func (e BucketNotEmptyError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultUnknown
+}

--- a/internal/rgw/bucket_helpers.go
+++ b/internal/rgw/bucket_helpers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/linode/provider-ceph/apis/provider-ceph/v1alpha1"
 )
@@ -81,4 +82,10 @@ func NoSuchBucket(err error) bool {
 	var noSuchBucketError *s3types.NoSuchBucket
 
 	return errors.As(err, &noSuchBucketError)
+}
+
+func IsNotEmpty(err error) bool {
+	var ae smithy.APIError
+
+	return errors.As(err, &ae) && ae.ErrorCode() == "BucketNotEmpty"
 }

--- a/internal/rgw/bucket_helpers.go
+++ b/internal/rgw/bucket_helpers.go
@@ -86,7 +86,7 @@ func NoSuchBucket(err error) bool {
 
 func IsNotEmpty(err error) bool {
 	var ae smithy.APIError
-	if errors.As(err, &ae) {
+	if !errors.As(err, &ae) {
 		return false
 	}
 

--- a/internal/rgw/bucket_helpers.go
+++ b/internal/rgw/bucket_helpers.go
@@ -86,6 +86,9 @@ func NoSuchBucket(err error) bool {
 
 func IsNotEmpty(err error) bool {
 	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return false
+	}
 
-	return errors.As(err, &ae) && ae.ErrorCode() == "BucketNotEmpty"
+	return ae != nil && ae.ErrorCode() == "BucketNotEmpty"
 }

--- a/internal/rgw/bucket_helpers_test.go
+++ b/internal/rgw/bucket_helpers_test.go
@@ -1,0 +1,64 @@
+package rgw
+
+import (
+	"testing"
+
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"true - BucketNotEmpty error": {
+			err:      bucketNotEmptyError{},
+			expected: true,
+		},
+		"false - Error not implement AWS API error": {
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		"false - Other AWS API error": {
+			err:      &s3types.NoSuchBucket{},
+			expected: false,
+		},
+	}
+
+	for name, tt := range testCases {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := IsNotEmpty(tt.err)
+
+			assert.Equal(t, tt.expected, actual, "result does not match")
+		})
+	}
+}
+
+// Unlike NoSuchBucket error or others, aws-sdk-go-v2 doesn't have a specific struct definition for BucketNotEmpty error.
+// So we should define ourselves for testing.
+type bucketNotEmptyError struct{}
+
+func (e bucketNotEmptyError) Error() string {
+	return "BucketNotEmpty: some error"
+}
+
+func (e bucketNotEmptyError) ErrorCode() string {
+	return "BucketNotEmpty"
+}
+
+func (e bucketNotEmptyError) ErrorMessage() string {
+	return "some error"
+}
+
+func (e bucketNotEmptyError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultUnknown
+}

--- a/internal/rgw/bucket_helpers_test.go
+++ b/internal/rgw/bucket_helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/smithy-go"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +16,7 @@ func TestIsNotEmpty(t *testing.T) {
 		expected bool
 	}{
 		"true - BucketNotEmpty error": {
-			err:      bucketNotEmptyError{},
+			err:      BucketNotEmptyError{},
 			expected: true,
 		},
 		"false - Error not implement AWS API error": {
@@ -41,24 +40,4 @@ func TestIsNotEmpty(t *testing.T) {
 			assert.Equal(t, tt.expected, actual, "result does not match")
 		})
 	}
-}
-
-// Unlike NoSuchBucket error or others, aws-sdk-go-v2 doesn't have a specific struct definition for BucketNotEmpty error.
-// So we should define ourselves for testing.
-type bucketNotEmptyError struct{}
-
-func (e bucketNotEmptyError) Error() string {
-	return "BucketNotEmpty: some error"
-}
-
-func (e bucketNotEmptyError) ErrorCode() string {
-	return "BucketNotEmpty"
-}
-
-func (e bucketNotEmptyError) ErrorMessage() string {
-	return "some error"
-}
-
-func (e bucketNotEmptyError) ErrorFault() smithy.ErrorFault {
-	return smithy.FaultUnknown
 }

--- a/internal/rgw/bucket_test.go
+++ b/internal/rgw/bucket_test.go
@@ -94,7 +94,7 @@ func TestDeleteBucket(t *testing.T) {
 				fake := &backendstorefakes.FakeS3Client{}
 				fake.HeadBucketReturns(nil, nil)
 
-				fake.DeleteBucketReturns(nil, bucketNotEmptyError{})
+				fake.DeleteBucketReturns(nil, BucketNotEmptyError{})
 
 				return fake
 			},

--- a/internal/rgw/bucket_test.go
+++ b/internal/rgw/bucket_test.go
@@ -1,0 +1,135 @@
+package rgw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/linode/provider-ceph/internal/backendstore/backendstorefakes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteBucket(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		s3BackendFunc func(err error) *backendstorefakes.FakeS3Client
+		healthCheck   bool
+		expectedErr   error
+	}{
+		"ok - non-healthcheck bucket": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				fake.DeleteBucketReturns(nil, nil)
+
+				return fake
+			},
+		},
+		"ok - healthcheck bucket": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				isTruncated := false
+				fake.ListObjectsV2Returns(&s3.ListObjectsV2Output{IsTruncated: &isTruncated}, nil)
+				fake.ListObjectVersionsReturns(&s3.ListObjectVersionsOutput{IsTruncated: &isTruncated}, nil)
+
+				fake.DeleteBucketReturns(nil, nil)
+
+				return fake
+			},
+			healthCheck: true,
+		},
+		"ok - bucket does not exist": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, &s3types.NotFound{})
+
+				return fake
+			},
+		},
+		"bucketExists returns unexpected error": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, err)
+
+				return fake
+			},
+			expectedErr: errors.New(errHeadBucket),
+		},
+		"delete objects returns error": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				fake.ListObjectsV2Returns(nil, err)
+				isTruncated := false
+				fake.ListObjectVersionsReturns(&s3.ListObjectVersionsOutput{IsTruncated: &isTruncated}, nil)
+
+				return fake
+			},
+			healthCheck: true,
+			expectedErr: errors.New(errListObjects),
+		},
+		"delete object versions returns error": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				isTruncated := false
+				fake.ListObjectsV2Returns(&s3.ListObjectsV2Output{IsTruncated: &isTruncated}, nil)
+				fake.ListObjectVersionsReturns(nil, err)
+
+				return fake
+			},
+			healthCheck: true,
+			expectedErr: errors.New(errListObjectVersions),
+		},
+		"bucket not empty error": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				fake.DeleteBucketReturns(nil, bucketNotEmptyError{})
+
+				return fake
+			},
+			expectedErr: ErrBucketNotEmpty,
+		},
+		"other error during backend bucket deletion": {
+			s3BackendFunc: func(err error) *backendstorefakes.FakeS3Client {
+				fake := &backendstorefakes.FakeS3Client{}
+				fake.HeadBucketReturns(nil, nil)
+
+				fake.DeleteBucketReturns(nil, err)
+
+				return fake
+			},
+			expectedErr: errors.New(errDeleteBucket),
+		},
+	}
+
+	bucketName := "test-bucket"
+
+	for name, tt := range testCases {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := tt.s3BackendFunc(tt.expectedErr)
+
+			err := DeleteBucket(context.Background(), client, &bucketName, tt.healthCheck)
+
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr, "error does not match")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes
In order to abort DeleteBucket operation if at least one backend bucket is not empty for non-healthcheck bucket, this PR does:
- Add a flag `healthCheck` into DeleteBucket method to determine if the bucket is healthcheck bucket or not.
- If the bucket is for healthchecking, the DeleteBucket method runs DeleteObjects and DelelteObjectVersions. Otherwise skip them
- In Delete method of bucket controller, if one of DeleteBucket operations returns `BucketNotEmpty` error, the method will changes the bucket CR's `disabled` flag to `false`. It makes Provider-Ceph abort bucket deletion process, and makes the bucket to be ready (although some other backends are already deleted)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
