### PR TITLE
More granular bucket conditions

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -98,7 +98,7 @@ func main() {
 		enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("false").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 
 		autoPauseBucket       = app.Flag("auto-pause-bucket", "Enable auto pause of reconciliation of ready buckets").Default("false").Envar("AUTO_PAUSE_BUCKET").Bool()
-		minReplicas           = app.Flag("minimum-replicas", "Minimum number of replicas of a bucket").Default("2").Envar("MINIMUM_REPLICAS").Uint()
+		minReplicas           = app.Flag("minimum-replicas", "Minimum number of replicas of a bucket before it is considered synced").Default("2").Envar("MINIMUM_REPLICAS").Uint()
 		recreateMissingBucket = app.Flag("recreate-missing-bucket", "Recreates existing bucket if missing").Default("true").Envar("RECREATE_MISSING_BUCKET").Bool()
 
 		assumeRoleArn = app.Flag("assume-role-arn", "Assume role ARN to be used for STS authentication").Default("").Envar("ASSUME_ROLE_ARN").String()

--- a/e2e/tests/stable/provider-ceph/14-assert.yaml
+++ b/e2e/tests/stable/provider-ceph/14-assert.yaml
@@ -51,8 +51,8 @@ status:
           status: "True"
           type: Ready
   conditions:
-  - reason: Unavailable
-    status: "False"
+  - reason: Available
+    status: "True"
     type: Ready
   - reason: ReconcileError
     status: "False"

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -2,7 +2,9 @@ package bucket
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -18,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 )
+
+const errUnavailableBackends = "Bucket is unavailable on the following backends: %s"
 
 // isBucketPaused returns true if the bucket has the paused label set.
 func isBucketPaused(bucket *v1alpha1.Bucket) bool {
@@ -141,14 +145,30 @@ func setBucketStatus(bucket *v1alpha1.Bucket, bucketBackends *bucketBackends, pr
 	bucket.Status.AtProvider.Backends = backends
 
 	ok := 0
-	for _, backend := range backends {
+	unavailableBackends := make([]string, 0)
+	for backendName, backend := range backends {
 		if backend.BucketCondition.Equal(xpv1.Available()) {
 			ok++
+
+			continue
 		}
+		unavailableBackends = append(unavailableBackends, backendName)
 	}
-	if ok > 0 && float64(ok) >= math.Min(float64(len(providerNames)), float64(minReplicas)) {
+	// The Bucket CR is considered Available if the bucket is available on any backend.
+	if ok > 0 {
 		bucket.Status.SetConditions(xpv1.Available())
 	}
+	// The Bucket CR is considered Synced (ReconcileSuccess) once the bucket is available
+	// on the lesser of all backends or minimum replicas.
+	if float64(ok) >= math.Min(float64(len(providerNames)), float64(minReplicas)) {
+		bucket.Status.SetConditions(xpv1.ReconcileSuccess())
+
+		return
+	}
+	// The Bucket CR cannot be considered Synced.
+	slices.Sort(unavailableBackends)
+	err := errors.New(fmt.Sprintf(errUnavailableBackends, strings.Join(unavailableBackends, ", ")))
+	bucket.Status.SetConditions(xpv1.ReconcileError(err))
 }
 
 type UpdateRequired int

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -128,6 +128,7 @@ func (c *external) updateOnAllBackends(ctx context.Context, bucket *v1alpha1.Buc
 	for backendName := range c.backendStore.GetActiveBackends(providerNames) {
 		if !c.backendStore.IsBackendActive(backendName) {
 			c.log.Info("Backend is marked inactive - bucket will not be updated on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
+			bb.setBucketCondition(bucket.Name, backendName, xpv1.Unavailable().WithMessage("Backend is marked inactive"))
 
 			continue
 		}
@@ -136,6 +137,7 @@ func (c *external) updateOnAllBackends(ctx context.Context, bucket *v1alpha1.Buc
 		if err != nil {
 			traces.SetAndRecordError(span, err)
 			c.log.Info("Failed to get client for backend - bucket cannot be updated on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName, "error", err.Error())
+			bb.setBucketCondition(bucket.Name, backendName, xpv1.Unavailable().WithMessage(err.Error()))
 
 			continue
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Clarify the meaning of minReplicas and enforce it by setting relevant conditions.
**Note:** We could make two flags `min-replicas-synced` and `min-replicas-ready`, right now the existing flag is effectively a `min-replicas-synced` flag - but I will leave this to a possible follow up PR if it's deemed necessary?
Also added conditions for skipped backends and more informative overall bucket Synced condition.
Also 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
CI + `make ceph-kuttl` + updated unit tests
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
