### PR TITLE
Fix PutLifecycleConfiguration's Prefix field

### DIFF
--- a/internal/rgw/lifecycleconfig_helpers.go
+++ b/internal/rgw/lifecycleconfig_helpers.go
@@ -33,9 +33,6 @@ func GenerateLifecycleRules(in []v1alpha1.LifecycleRule) []types.LifecycleRule {
 			ID:     local.ID,
 			Status: types.ExpirationStatus(local.Status),
 		}
-		if local.Prefix != nil {
-			rule.Prefix = local.Prefix //nolint:staticcheck // Support deprecated field.
-		}
 		if local.AbortIncompleteMultipartUpload != nil && local.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
 			rule.AbortIncompleteMultipartUpload = &types.AbortIncompleteMultipartUpload{
 				DaysAfterInitiation: local.AbortIncompleteMultipartUpload.DaysAfterInitiation,
@@ -89,8 +86,14 @@ func GenerateLifecycleRules(in []v1alpha1.LifecycleRule) []types.LifecycleRule {
 				rule.Transitions = append(rule.Transitions, transition)
 			}
 		}
-		// This is done because S3 expects an empty filter, and never nil
-		rule.Filter = &types.LifecycleRuleFilterMemberPrefix{}
+
+		if local.Prefix != nil {
+			rule.Prefix = local.Prefix //nolint:staticcheck // Support deprecated field.
+		} else {
+			// This is done because S3 expects an empty filter, and never nil if Prefix is not set.
+			rule.Filter = &types.LifecycleRuleFilterMemberPrefix{}
+		}
+
 		//nolint:nestif // Multiple checks required
 		if local.Filter != nil {
 			if local.Filter.Prefix != nil {

--- a/internal/rgw/lifecycleconfig_test.go
+++ b/internal/rgw/lifecycleconfig_test.go
@@ -60,7 +60,6 @@ func TestGenerateLifecycleConfigurationInput(t *testing.T) {
 								Expiration: &types.LifecycleExpiration{
 									Days: &days365,
 								},
-								Filter: &types.LifecycleRuleFilterMemberPrefix{},
 							},
 						},
 					},
@@ -148,7 +147,6 @@ func TestGenerateLifecycleConfigurationInput(t *testing.T) {
 								Expiration: &types.LifecycleExpiration{
 									Days: &days3650,
 								},
-								Filter: &types.LifecycleRuleFilterMemberPrefix{},
 								Transitions: []types.Transition{
 									{
 										Days:         &days365,


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR fixes the relationship between Prefix field and Filter field in LifecycleRule.

Currently, if a client want to set a LifecycleConfiguration with Prefix but without Filter, RGW can't take the Prefix field. It causes that the LifecycleConfiguration affects entire objects in the bucket.
Because:
1. RGW first checks if it can decode Filter field, then if not RGW tries if it can decode Prefix (Please see [here](https://github.com/ceph/ceph/blob/9c8f5bdec2c937e2beff0b0f8b9cb82070becd33/src/rgw/rgw_lc_s3.cc#L246-L256))
2. In our current `GenerateLifecycleRules` implementation, even if a client doesn't specify any Filter, the function sets empty `LifecycleRuleFilterMemberPrefix` instance.
3. Because RGW just checks if it can encode Filter field or not in the if-statement above, the empty LifecycleRuleFilterMemberPrefix instance is encoded and eventually Prefix field is dropped.


I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
