### PR TITLE
General tidy ups

### DIFF
--- a/e2e/tests/stable/chainsaw-test.yaml
+++ b/e2e/tests/stable/chainsaw-test.yaml
@@ -943,8 +943,6 @@ spec:
           kind: Bucket
           metadata:
             name: edge-case-bucket
-            labels:
-              provider-ceph.crossplane.io/validation-required: "true"
           spec:
             autoPause: true
             forProvider: {}

--- a/internal/controller/bucket/delete_test.go
+++ b/internal/controller/bucket/delete_test.go
@@ -682,7 +682,111 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			want: want{
-				err: rgw.ErrBucketNotEmpty,
+				err: nil,
+				statusDiff: func(t *testing.T, mg resource.Managed) {
+					t.Helper()
+					bucket, _ := mg.(*v1alpha1.Bucket)
+
+					// s3-backend-1 failed so is stuck in Deleting status.
+					assert.True(t,
+						bucket.Status.AtProvider.Backends[s3Backend1].BucketCondition.Equal(xpv1.Deleting().WithMessage(fmt.Errorf("%w: %w", rgw.ErrBucketNotEmpty, rgw.BucketNotEmptyError{}).Error())),
+						"unexpected bucket condition on s3-backend-1")
+
+					// s3-backend-2 was successfully deleted so was removed from status.
+					assert.False(t,
+						func(b v1alpha1.Backends) bool {
+							if _, ok := b[s3Backend2]; ok {
+								return true
+							}
+
+							return false
+						}(bucket.Status.AtProvider.Backends),
+						"s3-backend-2 should not exist in backends")
+
+					// If backend deletion fails due to BucketNotEmpty error, Disabled flag should be false.
+					assert.False(t,
+						bucket.Spec.Disabled,
+						"Disabled flag should be false",
+					)
+				},
+				finalizerDiff: func(t *testing.T, mg resource.Managed) {
+					t.Helper()
+					bucket, _ := mg.(*v1alpha1.Bucket)
+
+					assert.Equal(t,
+						[]string{v1alpha1.InUseFinalizer},
+						bucket.Finalizers,
+						"unexpeceted finalizers",
+					)
+				},
+			},
+		},
+		"Error deleting disabled bucket because one specified bucket is not empty": {
+			fields: fields{
+				backendStore: func() *backendstore.BackendStore {
+					// DeleteBucket first calls HeadBucket to establish
+					// if a bucket exists, so return a random error
+					// to mimic a failed delete.
+					fakeClient := &backendstorefakes.FakeS3Client{}
+					fakeClient.HeadBucketReturns(
+						&s3.HeadBucketOutput{},
+						nil,
+					)
+					fakeClient.DeleteBucketReturns(
+						nil,
+						rgw.BucketNotEmptyError{},
+					)
+
+					// DeleteBucket first calls HeadBucket to establish
+					// if a bucket exists, so return not found
+					// error to short circuit a successful delete.
+					var notFoundError *s3types.NotFound
+					fakeClientOK := &backendstorefakes.FakeS3Client{}
+					fakeClientOK.HeadBucketReturns(
+						&s3.HeadBucketOutput{},
+						notFoundError,
+					)
+
+					bs := backendstore.NewBackendStore()
+					bs.AddOrUpdateBackend(s3Backend1, fakeClient, nil, true, apisv1alpha1.HealthStatusHealthy)
+					bs.AddOrUpdateBackend(s3Backend2, fakeClientOK, nil, true, apisv1alpha1.HealthStatusHealthy)
+
+					return bs
+				}(),
+			},
+			args: args{
+				mg: &v1alpha1.Bucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "bucket",
+						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Labels: map[string]string{
+							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
+							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
+						},
+					},
+					Spec: v1alpha1.BucketSpec{
+						Providers: []string{
+							s3Backend1,
+							s3Backend2,
+						},
+						Disabled: true,
+					},
+					Status: v1alpha1.BucketStatus{
+						AtProvider: v1alpha1.BucketObservation{
+							Backends: v1alpha1.Backends{
+								s3Backend1: &v1alpha1.BackendInfo{
+									BucketCondition: xpv1.Available(),
+								},
+								s3Backend2: &v1alpha1.BackendInfo{
+									BucketCondition: xpv1.Available(),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
 				statusDiff: func(t *testing.T, mg resource.Managed) {
 					t.Helper()
 					bucket, _ := mg.(*v1alpha1.Bucket)

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -160,8 +160,10 @@ func setBucketStatus(bucket *v1alpha1.Bucket, bucketBackends *bucketBackends, pr
 		bucket.Status.SetConditions(xpv1.Available())
 	}
 	// The Bucket CR is considered Synced (ReconcileSuccess) once the bucket is available
-	// on the lesser of all backends or minimum replicas.
-	if float64(ok) >= math.Min(float64(len(providerNames)), float64(minReplicas)) {
+	// on the lesser of all backends or minimum replicas. We also ensure that the overall
+	// Bucket CR is available (in a Ready state) - this should already be the case.
+	if float64(ok) >= math.Min(float64(len(providerNames)), float64(minReplicas)) &&
+		bucket.Status.GetCondition(xpv1.TypeReady).Equal(xpv1.Available()) {
 		bucket.Status.SetConditions(xpv1.ReconcileSuccess())
 
 		return

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -146,14 +146,6 @@ func (c *external) updateOnAllBackends(ctx context.Context, bucket *v1alpha1.Buc
 	g := new(errgroup.Group)
 
 	for backendName := range c.backendStore.GetActiveBackends(allBackendsToUpdateOn) {
-		// TODO: Can we remove this check? we are already iterating over active backends only.
-		if !c.backendStore.IsBackendActive(backendName) {
-			c.log.Info("Backend is marked inactive - bucket will not be updated on backend", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
-			bb.setBucketCondition(bucket.Name, backendName, xpv1.Unavailable().WithMessage("Backend is marked inactive"))
-
-			continue
-		}
-
 		// Attempt to get an S3 client for the backend. This will either be the default
 		// S3 client created for each backend by the backend monitor or it will be a new
 		// temporary S3 client created via the STS AssumeRole endpoint. The latter will


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR is mostly comments explaining the flow - which can be difficult to follow at times. Also renamed a couple of variables a bit more verbosely which will also hopefully help.
There are also a couple of tidy ups in there - one in Delete which includes an added test case.
Also removed the spurious need for validation of a Bucket CR in a chainsaw test - this was a bit flaky due to errors attempting to reach the webhook.
Best to review this PR one commit at a time.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
CI + `make ceph-chainsaw`
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
