### PR TITLE
Remove the "in-use" Finalizer

### DIFF
--- a/apis/provider-ceph/v1alpha1/utils.go
+++ b/apis/provider-ceph/v1alpha1/utils.go
@@ -18,5 +18,4 @@ package v1alpha1
 
 const (
 	BackendLabelPrefix = "provider-ceph.backends."
-	InUseFinalizer     = "bucket-in-use.provider-ceph.crossplane.io"
 )

--- a/e2e/tests/ceph/chainsaw-test.yaml
+++ b/e2e/tests/ceph/chainsaw-test.yaml
@@ -81,7 +81,6 @@ spec:
             name: test-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
           status:
             atProvider:
               backends:
@@ -105,7 +104,6 @@ spec:
             name: test-bucket-all
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
           status:
             atProvider:
               backends:
@@ -185,7 +183,6 @@ spec:
             name: test-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
           status:
             atProvider:
               backends:
@@ -257,7 +254,6 @@ spec:
             name: test-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
           status:
             atProvider:
               backends:

--- a/e2e/tests/stable/chainsaw-test.yaml
+++ b/e2e/tests/stable/chainsaw-test.yaml
@@ -155,7 +155,6 @@ spec:
             name: lc-config-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               provider-ceph.backends.localstack-a: "true"
               provider-ceph.backends.localstack-b: "true"
@@ -220,7 +219,6 @@ spec:
             name: auto-pause-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               crossplane.io/paused: "true"
               provider-ceph.backends.localstack-a: "true"
@@ -377,7 +375,6 @@ spec:
             name: localstack-b-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
           status:
             atProvider:
               backends:
@@ -648,7 +645,6 @@ spec:
             name: auto-pause-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               crossplane.io/paused: "true"
               provider-ceph.backends.localstack-a: "true"
@@ -685,7 +681,6 @@ spec:
             name: avoid-localstack-c-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               provider-ceph.backends.localstack-a: "true"
               provider-ceph.backends.localstack-b: "true"
@@ -738,7 +733,6 @@ spec:
             name: auto-pause-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               crossplane.io/paused: "true"
               provider-ceph.backends.localstack-a: "true"
@@ -777,7 +771,6 @@ spec:
             name: avoid-localstack-c-bucket
             finalizers:
             - "finalizer.managedresource.crossplane.io"
-            - "bucket-in-use.provider-ceph.crossplane.io"
             labels:
               crossplane.io/paused: "true"
               provider-ceph.backends.localstack-a: "true"

--- a/examples/sample/bucket.yaml
+++ b/examples/sample/bucket.yaml
@@ -3,6 +3,4 @@ kind: Bucket
 metadata:
   name: test-bucket
 spec:
-  providers:
-  - ceph-admin-cfg
   forProvider: {}

--- a/internal/controller/bucket/delete_test.go
+++ b/internal/controller/bucket/delete_test.go
@@ -126,9 +126,8 @@ func TestDelete(t *testing.T) {
 	}
 
 	type want struct {
-		err           error
-		statusDiff    func(t *testing.T, mg resource.Managed)
-		finalizerDiff func(t *testing.T, mg resource.Managed)
+		err        error
+		statusDiff func(t *testing.T, mg resource.Managed)
 	}
 
 	cases := map[string]struct {
@@ -160,8 +159,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "test-bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "test-bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -212,15 +210,6 @@ func TestDelete(t *testing.T) {
 						}(bucket.Status.AtProvider.Backends),
 						"s3-backend-2 should not exist in backends")
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Empty(t,
-						len(bucket.Finalizers),
-						"unexpeceted finalizers",
-					)
-				},
 			},
 		},
 		"Delete buckets on all backends": {
@@ -246,8 +235,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "test-bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "test-bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -299,15 +287,6 @@ func TestDelete(t *testing.T) {
 						}(bucket.Status.AtProvider.Backends),
 						"s3-backend-2 should not exist in backends")
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Empty(t,
-						len(bucket.Finalizers),
-						"unexpeceted finalizers",
-					)
-				},
 			},
 		},
 		"Error deleting buckets on all specified backends": {
@@ -332,8 +311,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -372,16 +350,6 @@ func TestDelete(t *testing.T) {
 						bucket.Status.AtProvider.Backends[s3Backend2].BucketCondition.Equal(xpv1.Deleting().WithMessage(errors.Wrap(errRandom, "failed to perform head bucket").Error())),
 						"unexpected bucket condition on s3-backend-2")
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpected finalizers",
-					)
-				},
 			},
 		},
 		"Error deleting buckets on all backends": {
@@ -406,8 +374,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -442,16 +409,6 @@ func TestDelete(t *testing.T) {
 						bucket.Status.AtProvider.Backends[s3Backend2].BucketCondition.Equal(xpv1.Deleting().WithMessage(errors.Wrap(errRandom, "failed to perform head bucket").Error())),
 						"unexpected bucket condition on s3-backend-2")
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpected finalizers",
-					)
-				},
 			},
 		},
 
@@ -475,8 +432,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -510,16 +466,6 @@ func TestDelete(t *testing.T) {
 					assert.True(t,
 						bucket.Status.AtProvider.Backends[s3Backend2].BucketCondition.Equal(xpv1.Deleting().WithMessage(errors.Wrap(errors.Wrap(errRandom, "failed to assume role"), "Failed to create s3 client via assume role").Error())),
 						"unexpected bucket condition on s3-backend-2")
-				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpected finalizers",
-					)
 				},
 			},
 		},
@@ -556,8 +502,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -605,16 +550,6 @@ func TestDelete(t *testing.T) {
 						}(bucket.Status.AtProvider.Backends),
 						"s3-backend-2 should not exist in backends")
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpeceted finalizers",
-					)
-				},
 			},
 		},
 
@@ -654,8 +589,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -709,16 +643,6 @@ func TestDelete(t *testing.T) {
 						"Disabled flag should be false",
 					)
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpeceted finalizers",
-					)
-				},
 			},
 		},
 		"Error deleting disabled bucket because one specified bucket is not empty": {
@@ -757,8 +681,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket",
 						Labels: map[string]string{
 							v1alpha1.BackendLabelPrefix + s3Backend1: "true",
 							v1alpha1.BackendLabelPrefix + s3Backend2: "true",
@@ -813,16 +736,6 @@ func TestDelete(t *testing.T) {
 						"Disabled flag should be false",
 					)
 				},
-				finalizerDiff: func(t *testing.T, mg resource.Managed) {
-					t.Helper()
-					bucket, _ := mg.(*v1alpha1.Bucket)
-
-					assert.Equal(t,
-						[]string{v1alpha1.InUseFinalizer},
-						bucket.Finalizers,
-						"unexpeceted finalizers",
-					)
-				},
 			},
 		},
 	}
@@ -853,9 +766,6 @@ func TestDelete(t *testing.T) {
 			require.ErrorIs(t, err, tc.want.err, "unexpected err")
 			if tc.want.statusDiff != nil {
 				tc.want.statusDiff(t, tc.args.mg)
-			}
-			if tc.want.finalizerDiff != nil {
-				tc.want.finalizerDiff(t, tc.args.mg)
 			}
 		})
 	}

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -5,7 +5,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -46,13 +45,6 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if (bucket.Spec.AutoPause || c.autoPauseBucket) && !isBucketPaused(bucket) {
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: false,
-		}, nil
-	}
-
-	if !controllerutil.ContainsFinalizer(bucket, v1alpha1.InUseFinalizer) {
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,

--- a/internal/controller/bucket/observe_test.go
+++ b/internal/controller/bucket/observe_test.go
@@ -159,42 +159,6 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"Bucket doesn't have finalizer": {
-			fields: fields{
-				backendStore: func() *backendstore.BackendStore {
-					bs := backendstore.NewBackendStore()
-					bs.AddOrUpdateBackend("s3-backend-1", nil, nil, true, apisv1alpha1.HealthStatusHealthy)
-
-					return bs
-				}(),
-			},
-			args: args{
-				mg: &v1alpha1.Bucket{
-					Spec: v1alpha1.BucketSpec{
-						ResourceSpec: v1.ResourceSpec{
-							ProviderConfigReference: &v1.Reference{
-								Name: "s3-backend-1",
-							},
-						},
-					},
-					Status: v1alpha1.BucketStatus{
-						AtProvider: v1alpha1.BucketObservation{
-							Backends: v1alpha1.Backends{
-								"s3-backend-1": &v1alpha1.BackendInfo{
-									BucketCondition: v1.Available(),
-								},
-							},
-						},
-					},
-				},
-			},
-			want: want{
-				o: managed.ExternalObservation{
-					ResourceExists:   true,
-					ResourceUpToDate: false,
-				},
-			},
-		},
 		"Bucket status is not available": {
 			fields: fields{
 				backendStore: func() *backendstore.BackendStore {
@@ -206,9 +170,6 @@ func TestObserve(t *testing.T) {
 			},
 			args: args{
 				mg: &v1alpha1.Bucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Finalizers: []string{v1alpha1.InUseFinalizer},
-					},
 					Spec: v1alpha1.BucketSpec{
 						ResourceSpec: v1.ResourceSpec{
 							ProviderConfigReference: &v1.Reference{
@@ -252,9 +213,6 @@ func TestObserve(t *testing.T) {
 			},
 			args: args{
 				mg: &v1alpha1.Bucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Finalizers: []string{v1alpha1.InUseFinalizer},
-					},
 					Spec: v1alpha1.BucketSpec{
 						Providers: []string{"s3-backend-1"},
 						ResourceSpec: v1.ResourceSpec{
@@ -306,8 +264,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket-check-external-error",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket-check-external-error",
 					},
 					Spec: v1alpha1.BucketSpec{
 						Providers: []string{"s3-backend-1"},
@@ -361,8 +318,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket-check-external-not-exists",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket-check-external-not-exists",
 					},
 					Spec: v1alpha1.BucketSpec{
 						Providers: []string{"s3-backend-1"},
@@ -416,8 +372,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "bucket-check-external-ok",
-						Finalizers: []string{v1alpha1.InUseFinalizer},
+						Name: "bucket-check-external-ok",
 					},
 					Spec: v1alpha1.BucketSpec{
 						Providers: []string{"s3-backend-1"},
@@ -471,9 +426,6 @@ func TestObserve(t *testing.T) {
 			},
 			args: args{
 				mg: &v1alpha1.Bucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Finalizers: []string{v1alpha1.InUseFinalizer},
-					},
 					Spec: v1alpha1.BucketSpec{
 						Providers: []string{"s3-backend-1"},
 						ResourceSpec: v1.ResourceSpec{

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -121,9 +120,6 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 			// intended to be updated on. This is to ensure the bucket will eventually be updated
 			// on these backends whenever they become active again.
 			setAllBackendLabels(bucketLatest, allBackendsToUpdateOn)
-			// Add the in-use finalizer to ensure that the Bucket CR cannot be deleted while
-			// it has existing buckets.
-			controllerutil.AddFinalizer(bucketLatest, v1alpha1.InUseFinalizer)
 
 			return NeedsObjectUpdate
 		})


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The purpose of the `bucket-in-use` finalizer was to ensure that (1) a Bucket CR could not be removed whilst it still has corresponding S3 buckets existing on Ceph backends and (2) in a system where Bucket CRs are managed by a separate controller or component, a separate actor could not simply delete a Bucket CR (by accident or otherwise).

However, scenario (1) is covered by the Crossplane `managed` finalizer.
Scenario (2) is **not** covered by the `managed` finalizer, but upon reflection it should not be the responsibility of Provider Ceph to add an "in-use" finalizer. It should instead be the responsibility of the controller/component that creates the Bucket CR.

Provider Ceph managing it's own "in-use" finalizer causes an issue whereby failure to remove the finalizer after successful deletion is not requeued by Crossplane as it assumes that the only finalizer it should care about is its own `managed` finalizer.
This can lead to a scenario where deleting a Bucket CR can result in the successful removal of all buckets from backends, however the kube API update to remove the finalizer fails and the CR is left hanging forever.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
CI + e2e
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
