### PR TITLE
Use input list of provider names instead of that in spec

### DIFF
--- a/internal/controller/bucket/bucket_backends.go
+++ b/internal/controller/bucket/bucket_backends.go
@@ -143,7 +143,7 @@ func (b *bucketBackends) countBucketsAvailableOnBackends(bucket *v1alpha1.Bucket
 	return i
 }
 
-// isLifecycleConfigAvailableOnBackends checks the backends listed in Spec.Providers against
+// isLifecycleConfigAvailableOnBackends checks the backends listed in providerNames against
 // bucketBackends to ensure lifecycle configurations are considered Available on all desired backends.
 func (b *bucketBackends) isLifecycleConfigAvailableOnBackends(bucket *v1alpha1.Bucket, providerNames []string, c map[string]backendstore.S3Client) bool {
 	for _, backendName := range providerNames {
@@ -168,7 +168,7 @@ func (b *bucketBackends) isLifecycleConfigAvailableOnBackends(bucket *v1alpha1.B
 	return true
 }
 
-// isLifecycleConfigRemovedFromBackends checks the backends listed in Spec.Providers against
+// isLifecycleConfigRemovedFromBackends checks the backends listed in providerNames against
 // bucketBackends to ensure lifecycle configurations are removed from all desired backends.
 func (b *bucketBackends) isLifecycleConfigRemovedFromBackends(bucket *v1alpha1.Bucket, providerNames []string, c map[string]backendstore.S3Client) bool {
 	for _, backendName := range providerNames {

--- a/internal/controller/bucket/bucket_backends.go
+++ b/internal/controller/bucket/bucket_backends.go
@@ -145,8 +145,8 @@ func (b *bucketBackends) countBucketsAvailableOnBackends(bucket *v1alpha1.Bucket
 
 // isLifecycleConfigAvailableOnBackends checks the backends listed in Spec.Providers against
 // bucketBackends to ensure lifecycle configurations are considered Available on all desired backends.
-func (b *bucketBackends) isLifecycleConfigAvailableOnBackends(bucket *v1alpha1.Bucket, c map[string]backendstore.S3Client) bool {
-	for _, backendName := range bucket.Spec.Providers {
+func (b *bucketBackends) isLifecycleConfigAvailableOnBackends(bucket *v1alpha1.Bucket, providerNames []string, c map[string]backendstore.S3Client) bool {
+	for _, backendName := range providerNames {
 		if _, ok := c[backendName]; !ok {
 			// This backend does not exist in the list of available backends.
 			// The backend may be offline, so it is skipped.
@@ -170,8 +170,8 @@ func (b *bucketBackends) isLifecycleConfigAvailableOnBackends(bucket *v1alpha1.B
 
 // isLifecycleConfigRemovedFromBackends checks the backends listed in Spec.Providers against
 // bucketBackends to ensure lifecycle configurations are removed from all desired backends.
-func (b *bucketBackends) isLifecycleConfigRemovedFromBackends(bucket *v1alpha1.Bucket, c map[string]backendstore.S3Client) bool {
-	for _, backendName := range bucket.Spec.Providers {
+func (b *bucketBackends) isLifecycleConfigRemovedFromBackends(bucket *v1alpha1.Bucket, providerNames []string, c map[string]backendstore.S3Client) bool {
+	for _, backendName := range providerNames {
 		if _, ok := c[backendName]; !ok {
 			// This backend does not exist in the list of available backends.
 			// The backend may be offline, so it is skipped.

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -42,13 +42,13 @@ func isPauseRequired(bucket *v1alpha1.Bucket, providerNames []string, minReplica
 
 	// If lifecycle config is enabled and is specified in the spec, we should only pause once
 	// the lifecycle config is available on all backends.
-	if !bucket.Spec.LifecycleConfigurationDisabled && bucket.Spec.ForProvider.LifecycleConfiguration != nil && !bb.isLifecycleConfigAvailableOnBackends(bucket, c) {
+	if !bucket.Spec.LifecycleConfigurationDisabled && bucket.Spec.ForProvider.LifecycleConfiguration != nil && !bb.isLifecycleConfigAvailableOnBackends(bucket, providerNames, c) {
 		return false
 	}
 
 	// If lifecycle config is disabled, we should only pause once the lifecycle config is
 	// removed from all backends.
-	if bucket.Spec.LifecycleConfigurationDisabled && !bb.isLifecycleConfigRemovedFromBackends(bucket, c) {
+	if bucket.Spec.LifecycleConfigurationDisabled && !bb.isLifecycleConfigRemovedFromBackends(bucket, providerNames, c) {
 		return false
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Fix a bug where we were iterating over the list of providers in the Bucket Spec instead of iterating over an up-to-date list.
The providers listed in the bucket spec will often be empty by default, resulting in the looped check to be skipped.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Exiting CI + unit tests
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
