### PR TITLE
Update autopause docs

### DIFF
--- a/docs/AUTOPAUSE.md
+++ b/docs/AUTOPAUSE.md
@@ -1,13 +1,23 @@
 # Autopause
 
 ## Description
-Autopause leverages the existing [Crossplane pause feature](https://docs.crossplane.io/latest/concepts/managed-resources/#paused) which allows the user to pause reconciliation of a managed resource by applying a specific annotation to the managed resource's metadata. If Autopause is enabled, Provider Ceph will automatically pause a Bucket CR once all corresponding S3 buckets are in a `Ready` state on the relevant backends. It is also important to note that Provider Ceph, unlike most Crossplane Providers, uses labels instead of annotations to achieve this outcome.
+Crossplane has an existing [pause feature](https://docs.crossplane.io/latest/concepts/managed-resources/#paused) which allows the user to pause reconciliation of a managed resource by applying a specific annotation to the managed resource's metadata. Provider Ceph uses a variation of this mechanism to achieve the same result by using an identical label instead of the described annotation.
+
+The Provider Ceph controller manager, created upon start-up, caches only Bucket CRs which have _not_ been paused by the label. As such, only non-paused Bucket CRs will be reconciled by Provider Ceph, achieveing the desired "pause" effect. 
+
+If Autopause is enabled, Provider Ceph will automatically pause a Bucket CR once all corresponding S3 buckets are in a `Ready` state on the relevant backends and the CR is considered `Synced`.
 
 ## Enabling Autopause
  - Autopause can be enabled globally for **all Bucket CRs** by setting the appropriate Provider Ceph flag `--auto-pause-bucket=true`.
  - Autopause can also be enabled **per Bucket CR** by setting `autoPause: true` in the Bucket CR Spec. 
 
 **Note:** The global flag takes precedence over the setting of an individual Bucket CR.
+
+> [!WARNING]
+> It is the responsibility of the user/client to "unpause" a paused Bucket CR before performing an Update or Delete operation.
+
+## Updating a Paused Bucket
+A paused Bucket CR can be updated like any other CR. However, the changes will _not_ trigger a reconciliation of the CR by Provider Ceph. To temporarily "unpause" a Bucket CR to allow Provider Ceph to reconcile an update, the Bucket CR pause label must be set to an empty string `""`. This will result in Provider Ceph reconciling an updated CR and then pausing the Bucket CR once again after the update is complete and the CR is considered `Synced`.
 
 ## Deleting a Paused Bucket
 To temporarily "unpause" a Bucket CR to allow Provider Ceph to perform Delete, the Bucket CR must be patched, setting the pause label to `"false"` or some other value that is **not** an empty string `""`.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/linode/provider-ceph
 
 go 1.21
 
-toolchain go1.21.9
+toolchain go1.21.12
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Update to documentation (explains use of pause label instead of annotation) 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
