### PR TITLE
Simplify updateBucketCR

### DIFF
--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -105,7 +105,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	// the bucket CR. This is done by setting the Disabled flag on the bucket
 	// CR spec. If the deletion is successful or unsuccessful, the bucket CR status must be
 	// updated.
-	if err := c.updateBucketCR(ctx, bucket, func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
+	if err := c.updateBucketCR(ctx, bucket, func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
 		setBucketStatus(bucketLatest, bucketBackends, providerNames, c.minReplicas)
 
 		return NeedsStatusUpdate
@@ -130,7 +130,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 			if !bucket.Spec.Disabled {
 				return managed.ExternalDelete{}, nil
 			}
-			if err := c.updateBucketCR(ctx, bucket, func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
+			if err := c.updateBucketCR(ctx, bucket, func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
 				c.log.Info("Bucket CRs with non-empty buckets should not be disabled - setting 'disabled' flag to false", consts.KeyBucketName, bucket.Name)
 
 				bucketLatest.Spec.Disabled = false

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -211,70 +211,41 @@ const (
 // updateBucketCR updates the Bucket CR and/or the Bucket CR Status by applying a series of callbacks.
 // The function uses an exponential backoff retry mechanism to handle potential conflicts during updates.
 //
-// The callbacks take two Bucket parameters. Before the callbacks are called, the first Bucket
-// parameter will become a DeepCopy of bucket. The second will become the latest version of bucket, as it is fetched
-// from the Kube API. Each callback function should aim to update the latest version of the bucket (second parameter)
-// with the changes which will be persisted in bucket (and as a result, it's DeepCopy).
-//
 // Callbacks return an UpdateRequired status, depending on whether the update that is performed by the callback
 // requires a Bucket Status update (NeedsStatusUpdate) or a full Bucket object update (NeedsObjectUpdate).
 // This enables updateObject to make a decision on whether to perform kubeclient.Status().Update() or
 // kubeClient.Update() respectively.
 //
-// Callback example 1, updating the latest version of bucket Status with a field from your version of bucket.
-// This callback only performs an update to the Bucket Status, so NeedsStatusUpdate is returned to enabled
-// updateBucketCR to perform kubeClient.Status().Update().
+// Callback example, updating the latest version of bucket Status with a string, so NeedsStatusUpdate is
+// returned to enabled updateBucketCR to perform kubeClient.Status().Update().
 //
-//	 func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
-//		  bucketLatest.Status.SomeField = bucketDeepCopy.Status.SomeField
+//	func(bucketLatest *v1alpha1.Bucket) {
+//	  bucketLatest.Status.SomeOtherField = "some-value"
 //
-//	   return NeedsStatusUpdate
-//	 },
+//	  return NeedsStatusUpdate
+//	},
 //
-// Callback example 2, updating the latest version of bucket Status with a string:
+// Example usage with above callback example:
 //
-//		func(_, bucketLatest *v1alpha1.Bucket) {
-//		  bucketLatest.Status.SomeOtherField = "some-value"
+//	err := updateBucketCR(ctx, bucket, func(bucketLatest *v1alpha1.Bucket) {
+//	  bucketLatest.Status.SomeOtherField = "some-value"
 //
-//	   return NeedsStatusUpdate
-//		},
+//	  return NeedsStatusUpdate
+//	})
 //
-// Callback example 3, updating the latest version of bucket Spec with a field from your version of the bucket.
-// This callback performs an update to the Bucket Spec, so NeedsObjectUpdate is returned to enabled updateBucketCR
-// to perform a full kubeClient.Update().
-//
-//	 func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
-//		  bucketLatest.Spec.SomeField = bucketDeepCopy.Spec.SomeField
-//
-//	   return NeedsObjectUpdate
-//	 },
-//
-// Example usage with above callback example 3:
-//
-//		err := updateBucketCR(ctx, bucket, func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) {
-//		  bucketLatest.Spec.SomeField = bucketDeepCopy.Spec.SomeField
-//
-//	   return NeedsObjectUpdate
-//		})
-//
-//		if err != nil {
-//		  // Handle error
-//		}
-func (c *external) updateBucketCR(ctx context.Context, bucket *v1alpha1.Bucket, callbacks ...func(*v1alpha1.Bucket, *v1alpha1.Bucket) UpdateRequired) error {
+//	if err != nil {
+//	  // Handle error
+//	}
+func (c *external) updateBucketCR(ctx context.Context, bucket *v1alpha1.Bucket, callbacks ...func(*v1alpha1.Bucket) UpdateRequired) error {
 	ctx, span := otel.Tracer("").Start(ctx, "bucket.external.updateBucketCR")
 	defer span.End()
 
-	bucketDeepCopy := bucket.DeepCopy()
-
-	nn := types.NamespacedName{Name: bucket.GetName()}
-
 	for _, cb := range callbacks {
 		err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
-			if err := c.kubeClient.Get(ctx, nn, bucket); err != nil {
+			if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: bucket.GetName()}, bucket); err != nil {
 				return err
 			}
-
-			switch cb(bucketDeepCopy, bucket) {
+			switch cb(bucket) {
 			case NeedsStatusUpdate:
 				return c.kubeClient.Status().Update(ctx, bucket)
 			case NeedsObjectUpdate:

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -86,7 +86,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// Bucket CR Status in all cases to represent the conditions of each individual bucket.
 	cls := c.backendStore.GetBackendS3Clients(allBackendsToUpdateOn)
 	if err := c.updateBucketCR(ctx, bucket,
-		func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
+		func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
 			setBucketStatus(bucketLatest, bucketBackends, allBackendsToUpdateOn, c.minReplicas)
 
 			return NeedsStatusUpdate
@@ -100,7 +100,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// The buckets have been updated successfully on all backends, so we need to update the
 	// Bucket CR Spec accordingly.
 	err := c.updateBucketCR(ctx, bucket,
-		func(bucketDeepCopy, bucketLatest *v1alpha1.Bucket) UpdateRequired {
+		func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
 			if bucketLatest.ObjectMeta.Labels == nil {
 				bucketLatest.ObjectMeta.Labels = map[string]string{}
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The `bucketDeepCopy` parameter for the callback function is not used anywhere. Removing it as it unnecessarily complicates the logic and makes it difficult to follow.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing chainsaw tests/CI - no S3 calls affected.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
