### PR TITLE
Add otel round tripper to s3 client

### DIFF
--- a/internal/rgw/client.go
+++ b/internal/rgw/client.go
@@ -36,7 +36,10 @@ func NewS3Client(ctx context.Context, data map[string][]byte, pcSpec *apisv1alph
 
 	return s3.NewFromConfig(sessionConfig, func(o *s3.Options) {
 		o.UsePathStyle = true
-		o.HTTPClient = &http.Client{Timeout: s3Timeout}
+		o.HTTPClient = &http.Client{
+			Timeout:   s3Timeout,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		}
 		o.BaseEndpoint = &resolvedAddress
 		if sessionToken != nil {
 			o.APIOptions = []func(*middleware.Stack) error{


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add missing otel round tripper to S3 client (already exists in STS client) to enabling traces to be propagated to RGW.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
