### PR TITLE
Bump golangci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
   # Common versions
   GO_VERSION: '1.23'
   DOCKER_BUILDX_VERSION: 'v0.9.1'
+  GOLANGCI_VERSION: 'v2.1.6'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
   # step 'if env.XXX' != ""', so we copy these to succinctly test whether

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,117 +1,10 @@
+version: "2"
 run:
-  timeout: 3m
-
   issues-exit-code: 1
-
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats: colored-line-number
-
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: true
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: true
-
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    exclude-functions: fmt:.*,io/ioutil:^Read.*
-
-  govet:
-    # report about shadowed variables
-    check-shadowing: false
-
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/provider-template
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 12
-
-  cyclop:
-    max-complexity: 12
-    
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-
-  lll:
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-
-    # disabled-checks:
-    #   - unnamedResult
-    #   - hugeParam
-
-    settings: # settings passed to gocritic
-      captLocal: # must be valid enabled check name
-        paramsOnly: true
-      rangeValCopy:
-        sizeThreshold: 32
-
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-
+  formats:
+    text:
+      path: stdout
 linters:
   enable:
     - asasalint
@@ -123,7 +16,6 @@ linters:
     - copyloopvar
     - cyclop
     - decorder
-    # - depguard
     - dogsled
     - dupl
     - dupword
@@ -132,33 +24,27 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - errcheck
     - exhaustive
     - forbidigo
     - forcetypeassert
-    # - funlen
-    # - gci
     - gocheckcompilerdirectives
+    - gochecksumtype
     - gocognit
     - goconst
     - gocritic
-    # - godot
-    # - godox
-    - gofmt
-    - goimports
     - gocyclo
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
+    - gosmopolitan
     - loggercheck
     - maintidx
     - makezero
     - misspell
     - mnd
+    - musttag
     - nestif
     - nilerr
+    - nilnesserr
     - nilnil
     - nlreturn
     - noctx
@@ -166,96 +52,107 @@ linters:
     - paralleltest
     - prealloc
     - predeclared
+    - protogetter
     - reassign
-    # - revive
-    - staticcheck
-    # - stylecheck
-    - tenv
+    - recvcheck
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
     - thelper
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
-    # - varnamelen
     - whitespace
-    # - wrapcheck
-
-  presets:
-    - bugs
-    - unused
-  fast: false
-
-
+    - zerologlint
+  settings:
+    cyclop:
+      max-complexity: 12
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+      exclude-functions:
+        - fmt:.*
+        - io/ioutil:^Read.*
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      settings:
+        captLocal:
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+    gocyclo:
+      min-complexity: 12
+    lll:
+      tab-width: 1
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - exportloopref
+          - gocyclo
+          - gosec
+          - unparam
+        path: _test(ing)?\.go
+      - linters:
+          - gocritic
+        path: _test\.go
+        text: (unnamedResult|exitAfterDefer)
+      - linters:
+          - gocritic
+        text: '(hugeParam|rangeValCopy):'
+      - linters:
+          - staticcheck
+        text: 'SA3000:'
+      - linters:
+          - gosec
+        text: 'G101:'
+      - linters:
+          - gosec
+        text: 'G104:'
+    paths:
+      - zz_generated\..+\.go$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-files:
-  - "zz_generated\\..+\\.go$"
-
-  # Excluding configuration per-path and per-linter
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test(ing)?\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - exportloopref
-        - unparam
-    
-    # Ease some gocritic warnings on test files.
-    - path: _test\.go
-      text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
-
-    # These are performance optimisations rather than style issues per se.
-    # They warn when function arguments or range values copy a lot of memory
-    # rather than using a pointer.
-    - text: "(hugeParam|rangeValCopy):"
-      linters:
-      - gocritic
-
-    # This "TestMain should call os.Exit to set exit code" warning is not clever
-    # enough to notice that we call a helper method that calls os.Exit.
-    - text: "SA3000:"
-      linters:
-      - staticcheck
-
-    - text: "k8s.io/api/core/v1"
-      linters:
-      - goimports
-
-    # This is a "potential hardcoded credentials" warning. It's triggered by
-    # any variable with 'secret' in the same, and thus hits a lot of false
-    # positives in Kubernetes land where a Secret is an object type.
-    - text: "G101:"
-      linters:
-      - gosec
-      - gas
-
-    # This is an 'errors unhandled' warning that duplicates errcheck.
-    - text: "G104:"
-      linters:
-      - gosec
-      - gas
-
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing
-  # large codebase. It's not practical to fix all existing issues at the moment
-  # of integration: much better don't allow issues in new code.
-  # Default is false.
-  new: false
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+  new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/crossplane/provider-template
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated\..+\.go$
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
-GOLANGCILINT_VERSION ?= 1.61.0
+GOLANGCILINT_VERSION := $(shell grep 'GOLANGCI_VERSION' .github/workflows/ci.yml | sed -n 's/.*: *["'\'']*v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
+
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/internal/controller/bucket/bucket_validation_webhook.go
+++ b/internal/controller/bucket/bucket_validation_webhook.go
@@ -60,7 +60,7 @@ func (b *BucketValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		return nil, errors.New(errNotBucket)
 	}
 
-	if bucket.ObjectMeta.DeletionTimestamp != nil {
+	if bucket.DeletionTimestamp != nil {
 		return nil, nil
 	}
 

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -37,9 +37,9 @@ func isBucketPaused(bucket *v1alpha1.Bucket) bool {
 //
 //nolint:gocyclo,cyclop // Function requires numerous checks.
 func isPauseRequired(bucket *v1alpha1.Bucket, providerNames []string, c map[string]backendstore.S3Client, bb *bucketBackends, autopauseEnabled bool) bool {
-	// Avoid pausing if the Bucket CR is not Ready and Synced.
-	if !(bucket.Status.GetCondition(xpv1.TypeReady).Equal(xpv1.Available()) &&
-		bucket.Status.GetCondition(xpv1.TypeSynced).Equal(xpv1.ReconcileSuccess())) {
+	// Avoid pausing if the Bucket CR is not Ready or not Synced.
+	if !bucket.Status.GetCondition(xpv1.TypeReady).Equal(xpv1.Available()) ||
+		!bucket.Status.GetCondition(xpv1.TypeSynced).Equal(xpv1.ReconcileSuccess()) {
 		return false
 	}
 

--- a/internal/controller/bucket/helpers.go
+++ b/internal/controller/bucket/helpers.go
@@ -112,8 +112,8 @@ func isBucketAvailableFromStatus(bucket *v1alpha1.Bucket, providerNames []string
 // getAllBackendLabels returns all "provider-ceph.backends.<backend-name>" labels.
 func getAllBackendLabels(bucket *v1alpha1.Bucket, enabledOnly bool) map[string]string {
 	backends := map[string]string{}
-	for k, v := range bucket.ObjectMeta.Labels {
-		if !enabledOnly || strings.HasPrefix(k, v1alpha1.BackendLabelPrefix) && bucket.ObjectMeta.Labels[k] == True {
+	for k, v := range bucket.Labels {
+		if !enabledOnly || strings.HasPrefix(k, v1alpha1.BackendLabelPrefix) && bucket.Labels[k] == True {
 			backends[strings.Replace(k, v1alpha1.BackendLabelPrefix, "", 1)] = v
 		}
 	}
@@ -123,22 +123,22 @@ func getAllBackendLabels(bucket *v1alpha1.Bucket, enabledOnly bool) map[string]s
 
 // setAllBackendLabels adds label "provider-ceph.backends.<backend-name>" to the Bucket for each backend.
 func setAllBackendLabels(bucket *v1alpha1.Bucket, providerNames []string) {
-	if bucket.ObjectMeta.Labels == nil {
-		bucket.ObjectMeta.Labels = map[string]string{}
+	if bucket.Labels == nil {
+		bucket.Labels = map[string]string{}
 	}
 
 	// Delete existing labels except explicitly disabled backend labels.
 	for k := range getAllBackendLabels(bucket, true) {
-		delete(bucket.ObjectMeta.Labels, k)
+		delete(bucket.Labels, k)
 	}
 
 	for _, beName := range providerNames {
 		beLabel := utils.GetBackendLabel(beName)
-		if _, ok := bucket.ObjectMeta.Labels[beLabel]; ok {
+		if _, ok := bucket.Labels[beLabel]; ok {
 			continue
 		}
 
-		bucket.ObjectMeta.Labels[beLabel] = True
+		bucket.Labels[beLabel] = True
 	}
 }
 

--- a/internal/controller/bucket/update.go
+++ b/internal/controller/bucket/update.go
@@ -98,8 +98,8 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// Bucket CR Spec accordingly.
 	err := c.updateBucketCR(ctx, bucket,
 		func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
-			if bucketLatest.ObjectMeta.Labels == nil {
-				bucketLatest.ObjectMeta.Labels = map[string]string{}
+			if bucketLatest.Labels == nil {
+				bucketLatest.Labels = map[string]string{}
 			}
 
 			// Auto pause the Bucket CR if required - ie if auto-pause has been enabled and the

--- a/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
+++ b/internal/controller/providerconfig/healthcheck/healthcheck_controller_test.go
@@ -526,7 +526,7 @@ func TestReconcile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get ProviderConfig after reconcile: %s", err.Error())
 			}
-			assert.True(t, tc.want.pc.Status.ConditionedStatus.Equal(&pc.Status.ConditionedStatus), "unexpected condition")
+			assert.True(t, tc.want.pc.Status.Equal(&pc.Status.ConditionedStatus), "unexpected condition")
 
 			// Now check that the correct buckets have been unpaused.
 			if tc.want.bucketList == nil {

--- a/internal/controller/s3clienthandler/role_session_name_test.go
+++ b/internal/controller/s3clienthandler/role_session_name_test.go
@@ -38,7 +38,7 @@ func TestRoleSessionNameGenerator_Generate(t *testing.T) {
 				t.Helper()
 				require.Equal(t, 1, fake.GenerateCallCount())
 				prefix, length, charset := fake.GenerateArgsForCall(0)
-				require.Equal(t, "", prefix)
+				require.Empty(t, prefix)
 				require.Equal(t, roleSessionNameSuffixLength, length)
 				require.Same(t, charset, roleSessionNameSuffixCharset)
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Bump golangci-lint version to v2.1.6 and implement subsequent linting fixes.
Also, only set the golangci-lint version in the CI workflow so that Makefile is always up to date and we are not defining the version in two places.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
