### PR TITLE
Stop ignoring the ID field in comparisons between bucket lifecycles

### DIFF
--- a/package/webhookconfigurations/manifests.yaml
+++ b/package/webhookconfigurations/manifests.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -8,11 +7,15 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: provider-ceph
+      namespace: crossplane-system
       path: /validate-provider-ceph-ceph-crossplane-io-v1alpha1-bucket
+      port: 9443
   failurePolicy: Fail
   name: bucket-validation.providerceph.crossplane.io
+  objectSelector:
+    matchLabels:
+      provider-ceph.crossplane.io/validation-required: "true"
   rules:
   - apiGroups:
     - provider-ceph.ceph.crossplane.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Stop ignoring the rule's ID field when comparing two bucket lifecycle configs. This specific logic was copied from the upstream which was [introduced here](https://github.com/crossplane-contrib/provider-aws/pull/384/files#diff-ee9de706a0f71dc50232f280ed49736b41e1f913bae6ae093080666b25363090R78) without much context but it seems to be a safeguard for AWS which isn't our use case.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
