### PR TITLE
feat: Remove defaultregion

### DIFF
--- a/internal/rgw/client.go
+++ b/internal/rgw/client.go
@@ -22,10 +22,6 @@ import (
 	"github.com/linode/provider-ceph/internal/utils"
 )
 
-const (
-	defaultRegion = "us-east-1"
-)
-
 func NewS3Client(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration, sessionToken *string) (*s3.Client, error) {
 	sessionConfig, err := buildSessionConfig(ctx, data)
 	if err != nil {
@@ -78,7 +74,6 @@ func buildSessionConfig(ctx context.Context, data map[string][]byte) (aws.Config
 	return config.LoadDefaultConfig(ctx,
 		config.WithRetryMaxAttempts(retry.DefaultRetry.Steps),
 		config.WithRetryMode(aws.RetryModeStandard),
-		config.WithRegion(defaultRegion),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 			string(data[consts.KeyAccessKey]),
 			string(data[consts.KeySecretKey]),


### PR DESCRIPTION
By hardcoding the region from the config there is not way to overwrite it

With config: 
```
apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
kind: Bucket
metadata:
  name: test-bucket
spec:
  forProvider:
    locationConstraint: eu-de-2
```

Error: 

```
he authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-de-2'
  Warning  CannotCreateExternalResource  60s    managed/bucket.provider-ceph.ceph.crossplane.io  failed to create bucket: operation error S3: CreateBucket, https response error StatusCode: 400, RequestID: tx4e88be745e434ee29ff05-00685d4b4a, HostID: tx4e88be745e434ee29ff05-00685d4b4a, api error AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-de-2'
```

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
