### PR TITLE
Revert "feat: Remove default region (#346)"

### DIFF
--- a/internal/rgw/client.go
+++ b/internal/rgw/client.go
@@ -22,6 +22,10 @@ import (
 	"github.com/linode/provider-ceph/internal/utils"
 )
 
+const (
+	defaultRegion = "us-east-1"
+)
+
 func NewS3Client(ctx context.Context, data map[string][]byte, pcSpec *apisv1alpha1.ProviderConfigSpec, s3Timeout time.Duration, sessionToken *string) (*s3.Client, error) {
 	sessionConfig, err := buildSessionConfig(ctx, data)
 	if err != nil {
@@ -74,6 +78,7 @@ func buildSessionConfig(ctx context.Context, data map[string][]byte) (aws.Config
 	return config.LoadDefaultConfig(ctx,
 		config.WithRetryMaxAttempts(retry.DefaultRetry.Steps),
 		config.WithRetryMode(aws.RetryModeStandard),
+		config.WithRegion(defaultRegion),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 			string(data[consts.KeyAccessKey]),
 			string(data[consts.KeySecretKey]),


### PR DESCRIPTION
This reverts commit 2718a6c8adb9640c0cf2f4382fcf2c8f88790aac.

<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours betwee it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
