### PR TITLE
Remove check for unavailable buckets from delete flow

### DIFF
--- a/e2e/tests/stable/chainsaw-test.yaml
+++ b/e2e/tests/stable/chainsaw-test.yaml
@@ -667,6 +667,92 @@ spec:
               status: "False"
               type: Ready
 
+  # Create a bucket while localstack-a is still unhealthy, we will use this to verify
+  # that disabling a bucket on an unhealthy backend will fail.
+  - name: Apply unhealthy-backend-disable-bucket.
+    try:
+    - apply:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
+          spec:
+            autoPause: true
+            forProvider: {}
+    # Assert that unhealthy-backend-disable-bucket is created on localstack-b and -c.
+    - assert:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
+            finalizers:
+            - "finalizer.managedresource.crossplane.io"
+          status:
+            atProvider:
+              backends:
+                localstack-a:
+                  bucketCondition:
+                    reason: Unavailable
+                    status: "False"
+                    type: Ready
+                localstack-b:
+                  bucketCondition:
+                    reason: Available
+                    status: "True"
+                    type: Ready
+                localstack-c:
+                  bucketCondition:
+                    reason: Available
+                    status: "True"
+                    type: Ready
+            conditions:
+            - reason: Available
+              status: "True"
+              type: Ready
+            - reason: ReconcileError
+              status: "False"
+              type: Synced
+
+  - name: Disable unhealthy-backend-disable-bucket.
+    try:
+    - apply:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
+          spec:
+            disabled: true
+            autoPause: true
+            forProvider: {}
+
+    # Assert that disablement failed on localstack-a as it is still unreachable.
+    - assert:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
+            finalizers:
+            - "finalizer.managedresource.crossplane.io"
+          status:
+            atProvider:
+              backends:
+                localstack-a:
+                  bucketCondition:
+                    reason: Deleting
+                    status: "False"
+                    type: Ready
+            conditions:
+            - reason: Unavailable
+              status: "False"
+              type: Ready
+            - reason: ReconcileError
+              status: "False"
+              type: Synced
+
   - name: Make localstack-a reachable again and therefore Healthy.
     try:
     - command:
@@ -691,6 +777,71 @@ spec:
             - reason: HealthCheckSuccess
               status: "True"
               type: Ready
+
+    # Assert that disablement now succeeds on localstack-a after it has become reachable/healthy again.
+    - assert:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
+            finalizers:
+            - "finalizer.managedresource.crossplane.io"
+          status:
+            atProvider: {}
+            conditions:
+            - reason: Unavailable
+              status: "False"
+              type: Ready
+            - reason: ReconcileSuccess
+              status: "True"
+              type: Synced
+
+  - name: Check that unhealthy-backend-disable-bucket is now deleted from localstack-a.
+    try:
+    - command:
+        args:
+        - bucket_does_not_exist
+        - unhealthy-backend-disable-bucket
+        - local-dev-control-plane:32566
+        entrypoint: ../../../hack/expect_bucket.sh
+    - command:
+        args:
+        - bucket_does_not_exist
+        - unhealthy-backend-disable-bucket
+        - local-dev-control-plane:32567
+        entrypoint: ../../../hack/expect_bucket.sh
+    - command:
+        args:
+        - bucket_does_not_exist
+        - unhealthy-backend-disable-bucket
+        - local-dev-control-plane:32568
+        entrypoint: ../../../hack/expect_bucket.sh
+
+  - name: Delete unhealthy-backend-disable-bucket.
+    try:
+    - command:
+      # We need to "unpause" the bucket to allow deletion.
+        args:
+        - patch
+        - --type=merge
+        - buckets
+        - unhealthy-backend-disable-bucket
+        - -p
+        - '{"metadata":{"labels":{"crossplane.io/paused":"false"}}}'
+        entrypoint: kubectl
+    - command:
+        args:
+        - delete
+        - bucket
+        - unhealthy-backend-disable-bucket
+        entrypoint: kubectl
+    - error:
+        resource:
+          apiVersion: provider-ceph.ceph.crossplane.io/v1alpha1
+          kind: Bucket
+          metadata:
+            name: unhealthy-backend-disable-bucket
 
   - name: Scale localstack-a deployment to zero and therefore Unhealthy.
     try:

--- a/internal/controller/bucket/delete.go
+++ b/internal/controller/bucket/delete.go
@@ -64,10 +64,6 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 			log.Info("Skipping deletion of bucket on backend, missing status", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
 
 			continue
-		} else if reason := backend.BucketCondition.Reason; reason != xpv1.ReasonAvailable {
-			log.Info("Skipping deletion of bucket on backend, not available", consts.KeyBucketName, bucket.Name, consts.KeyBackendName, backendName)
-
-			continue
 		}
 
 		bucketBackends.setBucketCondition(bucket.Name, backendName, xpv1.Deleting())


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Orphaned S3 buckets (i.e. S3 bucket exists on Ceph backend(s) but CR has been fully removed) have been discovered on 2/3 occasions over the past year. 

Upon investigation, it turns out that in Provider Ceph's delete flow, as it iterates over the backends from which to delete a bucket, it skips over backends on which the bucket is "unavailable" (as per the CR status). The thing is that "unavailable" doesn't equate to "doesn't exist" - it just means that it's unreachable.
So a scenario could occur where a user creates a bucket while an RGW is unreachable and, as a result, Provider Ceph marks the bucket on that backend as "unavailable". But the bucket is created elsewhere so is still "ready" for the user. Then the user attempts to delete the bucket before Provider Ceph has a chance to fully sync all backends, and so this "unavailable" bucket gets skipped over during the deletion loop.

I don't know/remember why this check/skip was implemented. Either (1) it's just a mistake or (2) it was an attempt to avoid hanging CRs - if this is the case then I think hanging CRs is a much lesser evil than orphaned s3 buckets. 

There is also a check and skip over a backend which no longer exists in the Status - this is valid, as a deleting an S3 bucket should also mean that it is removed from the Status.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make ready-for-review` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours between it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
