### PR TITLE
Fix create delete infinite loop

### DIFF
--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -39,12 +39,23 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if len(bucket.Status.AtProvider.Backends) == 0 {
-		if bucket.Spec.Disabled {
-			// Bucket is disabled and has no backends — either it was never
-			// created, or Delete has already removed it from all backends.
-			// Either way, there is nothing for provider-ceph to act on so
-			// we return true/true for the external observation so that the
-			// Create/Delete methods are not called by crossplane-runtime.
+		if bucket.Spec.Disabled && bucket.GetDeletionTimestamp() == nil {
+			// This is an edge case:
+			// 1. The Bucket CR has no corresponding S3 bucket on any backends.
+			// 2. The Bucket CR is disabled.
+			// 3. The Bucket CR has NOT been deleted.
+			//
+			// Therefore we can assume its S3 buckets were never created on any backends or they
+			// were successfully removed when the CR was disabled. Either way, there is nothing
+			// for provider-ceph to do, so we return true/true for the external observation.
+			//
+			// This may seem counter intuitive given that the external resource does not exist.
+			// However, were we to return "ResourceExists: false" in this scenario, the crossplane
+			// runtime would update the "external-create-pending" annotation on the CR and call
+			// provider ceph's Create() method which will just return early as the CR is disabled.
+			// This results in an infinite loop of crossplane-runtime re-queuing the disabled CR
+			// and updating the same annotation repeatedly even though it is already in the desired
+			// state for a disabled CR. Over time these annotaion writes will fill up the ETCD DB.
 			return managed.ExternalObservation{
 				ResourceExists:   true,
 				ResourceUpToDate: true,

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -49,7 +49,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			// were successfully removed when the CR was disabled. Either way, there is nothing
 			// for provider-ceph to do, so we return true/true for the external observation.
 			//
-			// This may seem counter intuitive given that the external resource does not exist.
+			// This may seem counterintuitive given that the external resource does not exist.
 			// However, were we to return "ResourceExists: false" in this scenario, the crossplane
 			// runtime would update the "external-create-pending" annotation on the CR and call
 			// provider ceph's Create() method which will just return early as the CR is disabled.

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -39,6 +39,26 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if len(bucket.Status.AtProvider.Backends) == 0 {
+		if bucket.Spec.Disabled {
+			// Bucket is disabled and has no backends — either it was never
+			// created, or Delete has already removed it from all backends.
+			// Either way, there is nothing for provider-ceph to act on
+			// Only update the condition if not already Unavailable to avoid
+			// an etcd write on every reconcile.
+			if !bucket.Status.GetCondition(xpv1.TypeReady).Equal(xpv1.Unavailable()) {
+				if err := c.updateBucketCR(ctx, bucket, func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
+					bucketLatest.Status.SetConditions(xpv1.Unavailable())
+					return NeedsStatusUpdate
+				}); err != nil {
+					traces.SetAndRecordError(span, err)
+					return managed.ExternalObservation{}, err
+				}
+			}
+			return managed.ExternalObservation{
+				ResourceExists:   true,
+				ResourceUpToDate: true,
+			}, nil
+		}
 		return managed.ExternalObservation{
 			ResourceExists:   false,
 			ResourceUpToDate: true,

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -42,18 +42,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		if bucket.Spec.Disabled {
 			// Bucket is disabled and has no backends — either it was never
 			// created, or Delete has already removed it from all backends.
-			// Either way, there is nothing for provider-ceph to act on
-			// Only update the condition if not already Unavailable to avoid
-			// an etcd write on every reconcile.
-			if !bucket.Status.GetCondition(xpv1.TypeReady).Equal(xpv1.Unavailable()) {
-				if err := c.updateBucketCR(ctx, bucket, func(bucketLatest *v1alpha1.Bucket) UpdateRequired {
-					bucketLatest.Status.SetConditions(xpv1.Unavailable())
-					return NeedsStatusUpdate
-				}); err != nil {
-					traces.SetAndRecordError(span, err)
-					return managed.ExternalObservation{}, err
-				}
-			}
+			// Either way, there is nothing for provider-ceph to act on so
+			// we return true/true for the external observation so that the
+			// Create/Delete methods are not called by crossplane-runtime.
 			return managed.ExternalObservation{
 				ResourceExists:   true,
 				ResourceUpToDate: true,

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -55,7 +55,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			// provider ceph's Create() method which will just return early as the CR is disabled.
 			// This results in an infinite loop of crossplane-runtime re-queuing the disabled CR
 			// and updating the same annotation repeatedly even though it is already in the desired
-			// state for a disabled CR. Over time these annotaion writes will fill up the ETCD DB.
+			// state for a disabled CR. Over time these annotation writes will fill up the ETCD DB.
 			return managed.ExternalObservation{
 				ResourceExists:   true,
 				ResourceUpToDate: true,

--- a/internal/controller/bucket/observe.go
+++ b/internal/controller/bucket/observe.go
@@ -50,6 +50,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 				ResourceUpToDate: true,
 			}, nil
 		}
+
 		return managed.ExternalObservation{
 			ResourceExists:   false,
 			ResourceUpToDate: true,

--- a/internal/controller/bucket/observe_test.go
+++ b/internal/controller/bucket/observe_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -519,22 +518,6 @@ func TestObserveDisabledBucketNoBackendsDoesNotTriggerCreate(t *testing.T) {
 		// invokes Create (and its three annotation writes) when ResourceExists:false.
 		assert.True(t, obs.ResourceExists, "must be true to prevent Create being called")
 		assert.True(t, obs.ResourceUpToDate)
-
-		// Condition should be driven to Unavailable on the first observe.
-		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "disabled-no-backends"}, bucket))
-		assert.True(t, bucket.Status.GetCondition(v1.TypeReady).Equal(v1.Unavailable()))
-		rvAfterFirstObserve := bucket.ResourceVersion
-
-		// Second observe: condition is already Unavailable — no further write should occur.
-		obs, err = e.Observe(context.Background(), bucket)
-		require.NoError(t, err)
-		assert.True(t, obs.ResourceExists)
-		assert.True(t, obs.ResourceUpToDate)
-
-		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "disabled-no-backends"}, bucket))
-		// A stable ResourceVersion proves no etcd write happened on the second reconcile.
-		assert.Equal(t, rvAfterFirstObserve, bucket.ResourceVersion,
-			"no write should occur when condition is already Unavailable — reconciles are idempotent no-ops")
 	})
 
 	t.Run("non-disabled bucket with no backends still returns ResourceExists:false", func(t *testing.T) {

--- a/internal/controller/bucket/observe_test.go
+++ b/internal/controller/bucket/observe_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -470,4 +473,87 @@ func TestObserve(t *testing.T) {
 			assert.Equal(t, got, tc.want.o, "unexpected result")
 		})
 	}
+}
+
+// TestObserveDisabledBucketNoBackendsDoesNotTriggerCreate proves the fix for an etcd write loop.
+//
+// Root cause: a disabled bucket with empty backends caused Observe to return ResourceExists:false,
+// which triggered the Crossplane reconciler to call Create on every cycle — 3 etcd writes per
+// reconcile × thousands of buckets. The fix returns ResourceExists:true so Create is never invoked.
+func TestObserveDisabledBucketNoBackendsDoesNotTriggerCreate(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Bucket{}, &v1alpha1.BucketList{})
+
+	bs := backendstore.NewBackendStore()
+	bs.AddOrUpdateBackend("s3-backend-1", nil, nil, apisv1alpha1.HealthStatusHealthy)
+
+	t.Run("disabled bucket with no backends returns ResourceExists:true preventing Create", func(t *testing.T) {
+		t.Parallel()
+
+		// Exact state that caused the loop: disabled=true, backends={}, condition not yet Unavailable.
+		bucket := &v1alpha1.Bucket{
+			ObjectMeta: metav1.ObjectMeta{Name: "disabled-no-backends"},
+			Spec:       v1alpha1.BucketSpec{Disabled: true},
+			Status: v1alpha1.BucketStatus{
+				ResourceStatus: v1.ResourceStatus{
+					ConditionedStatus: v1.ConditionedStatus{
+						Conditions: []v1.Condition{v1.Creating()},
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(bucket).
+			WithStatusSubresource(bucket).
+			Build()
+
+		e := external{kubeClient: cl, kubeReader: cl, backendStore: bs, log: logr.Discard()}
+
+		obs, err := e.Observe(context.Background(), bucket)
+		require.NoError(t, err)
+		// ResourceExists:true is the gate that stops the loop — the Crossplane reconciler only
+		// invokes Create (and its three annotation writes) when ResourceExists:false.
+		assert.True(t, obs.ResourceExists, "must be true to prevent Create being called")
+		assert.True(t, obs.ResourceUpToDate)
+
+		// Condition should be driven to Unavailable on the first observe.
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "disabled-no-backends"}, bucket))
+		assert.True(t, bucket.Status.GetCondition(v1.TypeReady).Equal(v1.Unavailable()))
+		rvAfterFirstObserve := bucket.ResourceVersion
+
+		// Second observe: condition is already Unavailable — no further write should occur.
+		obs, err = e.Observe(context.Background(), bucket)
+		require.NoError(t, err)
+		assert.True(t, obs.ResourceExists)
+		assert.True(t, obs.ResourceUpToDate)
+
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "disabled-no-backends"}, bucket))
+		// A stable ResourceVersion proves no etcd write happened on the second reconcile.
+		assert.Equal(t, rvAfterFirstObserve, bucket.ResourceVersion,
+			"no write should occur when condition is already Unavailable — reconciles are idempotent no-ops")
+	})
+
+	t.Run("non-disabled bucket with no backends still returns ResourceExists:false", func(t *testing.T) {
+		t.Parallel()
+
+		bucket := &v1alpha1.Bucket{
+			ObjectMeta: metav1.ObjectMeta{Name: "enabled-no-backends"},
+		}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(bucket).
+			WithStatusSubresource(bucket).
+			Build()
+
+		e := external{kubeClient: cl, kubeReader: cl, backendStore: bs, log: logr.Discard()}
+
+		obs, err := e.Observe(context.Background(), bucket)
+		require.NoError(t, err)
+		assert.False(t, obs.ResourceExists, "active bucket with no backends must still trigger Create")
+	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Provider Ceph!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This pull request addresses an edge case in the S3 bucket controller where disabled buckets with no backends could cause an infinite etcd write loop. The main change ensures that such buckets are treated as "existing" to prevent unnecessary create operations, and a dedicated test is added to verify this behavior.

**Bugfix to prevent etcd write loops for disabled buckets:**

* Updated `Observe` logic in `observe.go` to return `ResourceExists: true` for disabled buckets with no backends, preventing repeated and unnecessary create attempts that could fill up etcd.

**Test coverage improvements:**

* Added `TestObserveDisabledBucketNoBackendsDoesNotTriggerCreate` in `observe_test.go` to prove that the fix prevents the etcd write loop by ensuring `ResourceExists: true` is returned in this scenario.
* Added necessary imports for `runtime` and `fake` client to support new tests
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

I have:

- [x] Run `make ready-for-review` to ensure this PR is ready for review.
- [ ] Run `make ceph-chainsaw` to validate these changes against Ceph. This step is not always necessary. However, for changes related to S3 calls it is sensible to validate against an actual Ceph cluster. Localstack is used in our CI Chainsaw suite for convenience and there can be disparity in S3 behaviours between it and Ceph. See `docs/TESTING.md` for information on how to run tests against a Ceph cluster.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Existing CI
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
